### PR TITLE
ci: phase 2 — reusable Go CI/release/Docker workflows + template housekeeping

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -47,6 +47,15 @@ jobs:
       packages: write
 
     steps:
+      - name: Validate version input
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if [ -z "$VERSION" ] || [ "$VERSION" = "edge" ]; then
+            echo "::error::docker-publish.yml does not accept empty or 'edge' versions (Phase 0: edge is artifacts-only)."
+            exit 1
+          fi
+
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
@@ -58,7 +67,9 @@ jobs:
       # source matches the version label.
       - name: Check out version tag (manual dispatch)
         if: github.event_name == 'workflow_dispatch'
-        run: git checkout "${{ inputs.version }}"
+        env:
+          VERSION: ${{ inputs.version }}
+        run: git checkout "$VERSION"
 
       - name: Compute build time
         id: build_time

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,118 @@
+---
+# Reusable Docker publish workflow
+# Source: oszuidwest/.github-templates
+#
+# Mirrors the audiologger Docker standard:
+# - Builds for stable + prerelease tags. Edge is artifacts-only (Phase 0); this
+#   workflow does not emit `:edge` Docker tags.
+# - BUILD_TIME computed at run time (UTC ISO-8601).
+# - provenance: false, sbom: false (opt in via fork if needed).
+# - For workflow_dispatch with an existing version tag, checks out that tag so
+#   the image source matches the label.
+
+name: Docker Publish
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: 'Release version, e.g. v1.2.3. Edge is not supported here.'
+        type: string
+        required: true
+      image-name:
+        description: 'Image name. Defaults to the calling repository (github.repository) when empty.'
+        type: string
+        default: ''
+      dockerfile-path:
+        description: 'Path to the Dockerfile.'
+        type: string
+        default: 'Dockerfile'
+      platforms:
+        description: 'Comma-separated Docker buildx platforms.'
+        type: string
+        default: 'linux/amd64,linux/arm64'
+      image-labels:
+        description: 'Multiline OCI image labels.'
+        type: string
+        default: ''
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      # When triggered by tag push, the chain is already at the tagged commit.
+      # When triggered by workflow_dispatch, the entry workflow ran on a branch
+      # and a tag was just created upstream — check that tag out so the image
+      # source matches the version label.
+      - name: Check out version tag (manual dispatch)
+        if: github.event_name == 'workflow_dispatch'
+        run: git checkout "${{ inputs.version }}"
+
+      - name: Compute build time
+        id: build_time
+        run: echo "value=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve image name
+        id: image
+        env:
+          IMAGE_NAME_INPUT: ${{ inputs.image-name }}
+          DEFAULT_IMAGE_NAME: ${{ github.repository }}
+        run: |
+          NAME="$IMAGE_NAME_INPUT"
+          if [ -z "$NAME" ]; then
+            NAME="$DEFAULT_IMAGE_NAME"
+          fi
+          echo "name=$NAME" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}
+          # type=semver patterns extract from values starting with 'v' (e.g. v1.2.3 -> 1.2.3).
+          # Pre-release tags (v1.0.0-rc1) only emit {{version}}; latest/major/minor are skipped.
+          tags: |
+            type=semver,pattern={{version}},value=${{ inputs.version }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ inputs.version }}
+            type=semver,pattern={{major}},value=${{ inputs.version }}
+            type=raw,value=latest,enable=${{ !contains(inputs.version, '-') }}
+          labels: ${{ inputs.image-labels }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ${{ inputs.dockerfile-path }}
+          platforms: ${{ inputs.platforms }}
+          push: true
+          pull: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          provenance: false
+          sbom: false
+          build-args: |
+            VERSION=${{ inputs.version }}
+            COMMIT=${{ github.sha }}
+            BUILD_TIME=${{ steps.build_time.outputs.value }}

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -1,0 +1,96 @@
+---
+# Reusable Go CI workflow
+# Source: oszuidwest/.github-templates
+#
+# Mirrors the audiologger CI standard: race-detected tests with shuffle, vet,
+# fmt drift check, pinned golangci-lint, deadcode, govulncheck, staticcheck.
+#
+# Optional `enable-frontend` flag adds a Bun lint job for repos that ship a
+# frontend alongside the Go service.
+
+name: Go CI
+
+on:
+  workflow_call:
+    inputs:
+      golangci-lint-version:
+        description: 'golangci-lint version (pinned, no v-prefix stripping)'
+        type: string
+        default: 'v2.12.1'
+      go-version-file:
+        description: 'Path to file used by setup-go to derive Go version'
+        type: string
+        default: 'go.mod'
+      enable-frontend:
+        description: 'Run a frontend lint job (Bun) alongside the Go job'
+        type: boolean
+        default: false
+      frontend-tool:
+        description: 'Frontend tool to use when enable-frontend is true. Only "bun" is supported in v1.'
+        type: string
+        default: 'bun'
+
+permissions:
+  contents: read
+
+jobs:
+  go:
+    name: Go
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: ${{ inputs.go-version-file }}
+          cache: true
+
+      - name: Download dependencies
+        run: go mod download
+
+      - name: Run tests
+        run: go test -race -shuffle=on -v ./...
+
+      - name: Run go vet
+        run: go vet ./...
+
+      - name: Check formatting
+        run: |
+          go fmt ./...
+          git diff --exit-code
+
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: ${{ inputs.golangci-lint-version }}
+          args: --timeout=5m
+
+      - name: Check for dead code
+        run: go tool deadcode ./...
+
+      - name: Run govulncheck
+        run: go tool govulncheck ./...
+
+      - name: Run staticcheck
+        run: go tool staticcheck ./...
+
+  frontend:
+    name: Frontend
+    if: inputs.enable-frontend
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Verify frontend tool
+        if: inputs.frontend-tool != 'bun'
+        run: |
+          echo "::error::frontend-tool '${{ inputs.frontend-tool }}' is not supported in v1. Only 'bun' is implemented."
+          exit 1
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Lint
+        run: bun run lint

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -3,10 +3,13 @@
 # Source: oszuidwest/.github-templates
 #
 # Mirrors the audiologger release standard:
-# - Tag push or workflow_dispatch with `edge` or `vX.Y.Z` (or `X.Y.Z`, auto-prefixed).
+# - Tag push or workflow_call with `version: edge` or `vX.Y.Z` (or `X.Y.Z`).
 # - Tag re-run guard so workflow_dispatch can be re-run on existing tags.
+#   When a tag already exists, that tag is checked out so the build matches
+#   the tag (no asset/image divergence between release.yml and docker-publish.yml).
 # - Race-detected tests with shuffle.
-# - Build matrix from JSON input, ldflags inject Version/Commit/BuildTime.
+# - Tests run BEFORE tag creation (fail-fast on a manual dispatch).
+# - Build matrix from JSON input, ldflags inject PascalCase Version/Commit/BuildTime.
 # - GitHub Release with prerelease auto-detect via contains(version, '-').
 # - Edge artifact: <project>-edge-<sha>, no Docker push for edge.
 # - Optional Docker publish for releases via docker-publish.yml.
@@ -21,13 +24,26 @@ on:
         type: string
         required: true
       ldflags-target:
-        description: 'Go package path where Version/Commit/BuildTime are injected (e.g. "main" or "github.com/org/repo/pkg/version").'
+        description: >-
+          Go package path where PascalCase Version/Commit/BuildTime are injected
+          (e.g. "main" or "github.com/org/repo/pkg/version"). Symbols MUST be
+          PascalCase: Version, Commit, BuildTime.
         type: string
         required: true
       build-matrix:
         description: 'JSON array of build targets, e.g. [{"os":"linux","arch":"amd64"},{"os":"linux","arch":"arm","arm":"7"}].'
         type: string
         required: true
+      main-package:
+        description: 'Go main package path passed to `go build` (default: ".").'
+        type: string
+        default: '.'
+      version:
+        description: >-
+          Release version when triggered via a consumer workflow_dispatch.
+          Accepts "edge", "vX.Y.Z", or "X.Y.Z". Leave empty for tag pushes.
+        type: string
+        default: ''
       enable-docker:
         description: 'Trigger docker-publish.yml for releases (not for edge).'
         type: boolean
@@ -67,12 +83,17 @@ jobs:
       - name: Determine version
         id: version
         env:
-          INPUT_VERSION: ${{ github.event.inputs.version }}
+          INPUT_VERSION: ${{ inputs.version }}
           EVENT_NAME: ${{ github.event_name }}
         run: |
-          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+          if [ "$EVENT_NAME" = "workflow_call" ] || [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            if [ -z "$INPUT_VERSION" ]; then
+              echo "::error::version input is required when invoked via workflow_call/workflow_dispatch."
+              exit 1
+            fi
             if [ "$INPUT_VERSION" = "edge" ]; then
-              echo "version=edge" >> "$GITHUB_OUTPUT"
+              SHORT_SHA=$(git rev-parse --short HEAD)
+              echo "version=edge-${SHORT_SHA}" >> "$GITHUB_OUTPUT"
               echo "is_release=false" >> "$GITHUB_OUTPUT"
             else
               # Auto-prefix v if user typed "1.2.3" instead of "v1.2.3"
@@ -102,6 +123,23 @@ jobs:
           go fmt ./...
           git diff --exit-code
 
+      - name: Create or check out version tag (manual release)
+        if: github.event_name != 'push' && steps.version.outputs.is_release == 'true'
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          if git rev-parse -q --verify "refs/tags/$VERSION" >/dev/null; then
+            echo "Tag $VERSION already exists; checking it out so the build matches the tag."
+          else
+            git tag "$VERSION"
+            git push origin "refs/tags/$VERSION"
+          fi
+          # Always end on the tag commit so build artifacts and Docker image
+          # come from the same source as the version label.
+          git checkout "refs/tags/$VERSION"
+
       - name: Build binaries
         env:
           VERSION: ${{ steps.version.outputs.version }}
@@ -109,12 +147,8 @@ jobs:
           PROJECT: ${{ inputs.project-name }}
           LDFLAGS_TARGET: ${{ inputs.ldflags-target }}
           BUILD_MATRIX: ${{ inputs.build-matrix }}
+          MAIN_PACKAGE: ${{ inputs.main-package }}
         run: |
-          # Edge builds embed the short SHA so artifacts are traceable to a commit.
-          if [ "$VERSION" = "edge" ]; then
-            VERSION="edge-$(git rev-parse --short HEAD)"
-          fi
-
           mkdir -p dist
           BUILD_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
@@ -132,22 +166,8 @@ jobs:
             env GOOS="$GOOS" GOARCH="$GOARCH" GOARM="$GOARM" CGO_ENABLED=0 go build \
               -ldflags="-s -w -X ${LDFLAGS_TARGET}.Version=${VERSION} -X ${LDFLAGS_TARGET}.Commit=${COMMIT} -X ${LDFLAGS_TARGET}.BuildTime=${BUILD_TIME}" \
               -o "dist/${output_name}" \
-              .
+              "${MAIN_PACKAGE}"
           done
-
-      - name: Create git tag (manual release)
-        if: github.event_name == 'workflow_dispatch' && steps.version.outputs.is_release == 'true'
-        env:
-          VERSION: ${{ steps.version.outputs.version }}
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          if git rev-parse -q --verify "refs/tags/$VERSION" >/dev/null; then
-            echo "Tag $VERSION already exists; reusing it for the release."
-          else
-            git tag "$VERSION"
-            git push origin "refs/tags/$VERSION"
-          fi
 
       - name: Create GitHub Release
         if: steps.version.outputs.is_release == 'true'

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -1,0 +1,183 @@
+---
+# Reusable Go release workflow
+# Source: oszuidwest/.github-templates
+#
+# Mirrors the audiologger release standard:
+# - Tag push or workflow_dispatch with `edge` or `vX.Y.Z` (or `X.Y.Z`, auto-prefixed).
+# - Tag re-run guard so workflow_dispatch can be re-run on existing tags.
+# - Race-detected tests with shuffle.
+# - Build matrix from JSON input, ldflags inject Version/Commit/BuildTime.
+# - GitHub Release with prerelease auto-detect via contains(version, '-').
+# - Edge artifact: <project>-edge-<sha>, no Docker push for edge.
+# - Optional Docker publish for releases via docker-publish.yml.
+
+name: Go Release
+
+on:
+  workflow_call:
+    inputs:
+      project-name:
+        description: 'Project name. Used as edge artifact prefix and binary basename.'
+        type: string
+        required: true
+      ldflags-target:
+        description: 'Go package path where Version/Commit/BuildTime are injected (e.g. "main" or "github.com/org/repo/pkg/version").'
+        type: string
+        required: true
+      build-matrix:
+        description: 'JSON array of build targets, e.g. [{"os":"linux","arch":"amd64"},{"os":"linux","arch":"arm","arm":"7"}].'
+        type: string
+        required: true
+      enable-docker:
+        description: 'Trigger docker-publish.yml for releases (not for edge).'
+        type: boolean
+        default: false
+      image-labels:
+        description: 'Multiline image labels passed through to docker-publish.yml.'
+        type: string
+        default: ''
+      dockerfile-path:
+        description: 'Dockerfile path passed through to docker-publish.yml.'
+        type: string
+        default: 'Dockerfile'
+      platforms:
+        description: 'Docker platforms passed through to docker-publish.yml.'
+        type: string
+        default: 'linux/amd64,linux/arm64'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      is_release: ${{ steps.version.outputs.is_release }}
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
+      - name: Determine version
+        id: version
+        env:
+          INPUT_VERSION: ${{ github.event.inputs.version }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            if [ "$INPUT_VERSION" = "edge" ]; then
+              echo "version=edge" >> "$GITHUB_OUTPUT"
+              echo "is_release=false" >> "$GITHUB_OUTPUT"
+            else
+              # Auto-prefix v if user typed "1.2.3" instead of "v1.2.3"
+              case "$INPUT_VERSION" in
+                v*) VERSION="$INPUT_VERSION" ;;
+                *)  VERSION="v$INPUT_VERSION" ;;
+              esac
+              echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+              echo "is_release=true" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo "version=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+            echo "is_release=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Download dependencies
+        run: go mod download
+
+      - name: Run tests
+        run: go test -race -shuffle=on -v ./...
+
+      - name: Run go vet
+        run: go vet ./...
+
+      - name: Check formatting
+        run: |
+          go fmt ./...
+          git diff --exit-code
+
+      - name: Build binaries
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          COMMIT: ${{ github.sha }}
+          PROJECT: ${{ inputs.project-name }}
+          LDFLAGS_TARGET: ${{ inputs.ldflags-target }}
+          BUILD_MATRIX: ${{ inputs.build-matrix }}
+        run: |
+          # Edge builds embed the short SHA so artifacts are traceable to a commit.
+          if [ "$VERSION" = "edge" ]; then
+            VERSION="edge-$(git rev-parse --short HEAD)"
+          fi
+
+          mkdir -p dist
+          BUILD_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+          echo "$BUILD_MATRIX" | jq -c '.[]' | while read -r entry; do
+            GOOS=$(echo "$entry" | jq -r '.os')
+            GOARCH=$(echo "$entry" | jq -r '.arch')
+            GOARM=$(echo "$entry" | jq -r '.arm // empty')
+
+            output_name="${PROJECT}-${VERSION}-${GOOS}-${GOARCH}"
+            [ -n "$GOARM" ] && output_name="${output_name}v${GOARM}"
+            [ "$GOOS" = "windows" ] && output_name="${output_name}.exe"
+
+            echo "Building $output_name"
+
+            env GOOS="$GOOS" GOARCH="$GOARCH" GOARM="$GOARM" CGO_ENABLED=0 go build \
+              -ldflags="-s -w -X ${LDFLAGS_TARGET}.Version=${VERSION} -X ${LDFLAGS_TARGET}.Commit=${COMMIT} -X ${LDFLAGS_TARGET}.BuildTime=${BUILD_TIME}" \
+              -o "dist/${output_name}" \
+              .
+          done
+
+      - name: Create git tag (manual release)
+        if: github.event_name == 'workflow_dispatch' && steps.version.outputs.is_release == 'true'
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          if git rev-parse -q --verify "refs/tags/$VERSION" >/dev/null; then
+            echo "Tag $VERSION already exists; reusing it for the release."
+          else
+            git tag "$VERSION"
+            git push origin "refs/tags/$VERSION"
+          fi
+
+      - name: Create GitHub Release
+        if: steps.version.outputs.is_release == 'true'
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ steps.version.outputs.version }}
+          files: dist/*
+          generate_release_notes: true
+          draft: false
+          prerelease: ${{ contains(steps.version.outputs.version, '-') }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload edge artifacts
+        if: steps.version.outputs.is_release == 'false'
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ inputs.project-name }}-edge-${{ github.sha }}
+          path: dist/*
+          retention-days: 7
+
+  docker:
+    needs: release
+    if: inputs.enable-docker && needs.release.outputs.is_release == 'true' && needs.release.result == 'success'
+    uses: ./.github/workflows/docker-publish.yml
+    with:
+      version: ${{ needs.release.outputs.version }}
+      dockerfile-path: ${{ inputs.dockerfile-path }}
+      platforms: ${{ inputs.platforms }}
+      image-labels: ${{ inputs.image-labels }}
+    permissions:
+      contents: read
+      packages: write

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ jobs:
       project-name: zwfm-metadata
       ldflags-target: zwfm-metadata/utils
       build-matrix: '[{"os":"linux","arch":"amd64"},{"os":"linux","arch":"arm64"},{"os":"darwin","arch":"arm64"}]'
+      version: ${{ inputs.version }}
       enable-docker: true
       image-labels: |
         org.opencontainers.image.title=ZuidWest FM Metadata
@@ -80,19 +81,35 @@ jobs:
       packages: write
 ```
 
-Inputs: `project-name`, `ldflags-target`, `build-matrix` (JSON), `image-labels` (multiline), `enable-docker` (default `false`).
+Inputs: `project-name`, `ldflags-target`, `build-matrix` (JSON), `main-package` (default `.` — set to `./cmd/foo` for repos with a non-root main), `version` (forward `inputs.version` from the consumer's `workflow_dispatch`; leave empty for tag pushes), `image-labels` (multiline), `enable-docker` (default `false`).
+
+**LDFLAGS contract:** the workflow injects PascalCase symbols `Version`, `Commit`, `BuildTime` at the package path you pass in `ldflags-target`. The Go package must declare those exact identifiers (e.g. `var Version, Commit, BuildTime string`). Lowercase names (`version`, `buildTime`) are not patched.
 
 ### `docker-publish.yml` — reusable Docker build/push
 
-Called transitively by `go-release.yml` when `enable-docker: true`. Direct call only when a repo has its own release flow.
+Called transitively by `go-release.yml` when `enable-docker: true`. Direct call only when a repo has its own release flow:
 
-Inputs: `version`, `image-name` (default `${{ github.repository }}`), `dockerfile-path` (default `Dockerfile`), `platforms` (default `linux/amd64,linux/arm64`), `image-labels`.
+```yaml
+jobs:
+  publish:
+    uses: oszuidwest/.github-templates/.github/workflows/docker-publish.yml@v1
+    with:
+      version: ${{ github.ref_name }}  # only call from a tag push or after tagging
+    permissions:
+      contents: read
+      packages: write
+```
+
+Inputs: `version` (required, must be non-empty and not `edge` — the workflow rejects edge per Phase 0), `image-name` (default `${{ github.repository }}`), `dockerfile-path` (default `Dockerfile`), `platforms` (default `linux/amd64,linux/arm64`), `image-labels`.
 
 ## Maintenance contract
 
 - **Versioning:** semver. Minor for additive optional inputs, major for breaking changes (renamed/removed inputs, default changes that break consumers). Both an immutable `v1.x.y` and a moving `v1` tag exist; consumers pin to `@v1` to follow fixes, `@v1.x.y` to freeze.
 - **Bumps:** dependabot via `github-actions` ecosystem in this repo + each consumer.
 - **Phase 0 standards** (locked in): action major-pinning, `golangci-lint` pinned, race detection required (`-race -shuffle=on`), `:edge` Docker tag NOT published (artifacts only), `BUILD_TIME` from `date -u`, `provenance: false` and `sbom: false` (opt-in only).
+- **Action-pinning exceptions:** major-pinning is the default. Some upstream actions don't publish a moving major tag — for those, pin to the most specific tag they publish:
+  - `ludeeus/action-shellcheck` — patch tag (e.g. `@2.0.0`); upstream has no `@v2`/`@2`.
+  - `aquasecurity/trivy-action` — release tag (e.g. `@0.36.0`); upstream uses `0.x.0` schema, no major tag.
 - **Drift before templating:** new copy-paste templates only after audiologger-style hand-alignment proves the shape on at least two consumers. Don't template a shape that hasn't stabilized.
 
 ## Troubleshooting

--- a/README.md
+++ b/README.md
@@ -1,31 +1,30 @@
 # GitHub Actions Templates
 
-Standard workflows for Docker-based repositories at oszuidwest.
+Shared GitHub Actions for repositories at oszuidwest. Two delivery models:
 
-## Quick Start
+- **Copy-paste templates** (`workflow-templates/`, `config-templates/`) — drop-in files. Use for project-shaped pieces (Dockerfile linting, Trivy scan, shellcheck) where the consumer barely customizes.
+- **Reusable workflows** (`.github/workflows/`) — called via `uses: oszuidwest/.github-templates/.github/workflows/<name>.yml@v1`. Use for the larger Go CI/release/Docker pipeline where parameterization replaces copy-paste drift.
+
+## Copy-paste templates
 
 ```bash
 # Workflows
 cp workflow-templates/docker-quality.yml   .github/workflows/
 cp workflow-templates/docker-security.yml  .github/workflows/
 cp workflow-templates/shell-quality.yml    .github/workflows/
-cp workflow-templates/cleanup-ghcr.yml     .github/workflows/
 
 # Config
 cp config-templates/.hadolint.yaml         ./
 cp config-templates/dependabot.yml         .github/
 ```
 
-## Workflows
-
 | Workflow | Purpose | Fails on |
 |----------|---------|----------|
 | docker-quality | Dockerfile, YAML and Compose linting | Lint errors |
 | docker-security | Vulnerability scanning (Trivy) | CRITICAL CVEs |
 | shell-quality | ShellCheck (only on .sh changes) | Lint errors |
-| cleanup-ghcr | Remove untagged images (weekly) | Never |
 
-## Customization
+### Customization
 
 **Dockerfile not in root?**
 ```yaml
@@ -33,9 +32,68 @@ env:
   DOCKERFILE_PATH: "docker/Dockerfile"
 ```
 
-**Multiple container images?** See matrix variant in `cleanup-ghcr.yml`.
-
 **Adjust Hadolint rules?** Edit `.hadolint.yaml`, not the workflow.
+
+## Reusable workflows (Phase 2)
+
+Call from the consumer repo's own `.github/workflows/` files. Pinning to `@v1` follows template fixes automatically; pinning to `@v1.0.0` freezes.
+
+### `go-ci.yml` — Go CI
+
+```yaml
+name: CI
+on:
+  push: { branches: [main], paths: ['**.go', 'go.mod', 'go.sum'] }
+  pull_request: { branches: [main], paths: ['**.go', 'go.mod', 'go.sum'] }
+permissions: { contents: read }
+jobs:
+  ci:
+    uses: oszuidwest/.github-templates/.github/workflows/go-ci.yml@v1
+    with:
+      golangci-lint-version: v2.12.1
+```
+
+Inputs: `golangci-lint-version` (default `v2.12.1`), `go-version-file` (default `go.mod`), `enable-frontend` (default `false`), `frontend-tool` (default `bun`).
+
+### `go-release.yml` — Go release
+
+```yaml
+name: Release
+on:
+  push: { tags: ['v*'] }
+  workflow_dispatch:
+    inputs:
+      version: { description: 'Version to build', required: true, default: 'edge' }
+jobs:
+  release:
+    uses: oszuidwest/.github-templates/.github/workflows/go-release.yml@v1
+    with:
+      project-name: zwfm-metadata
+      ldflags-target: zwfm-metadata/utils
+      build-matrix: '[{"os":"linux","arch":"amd64"},{"os":"linux","arch":"arm64"},{"os":"darwin","arch":"arm64"}]'
+      enable-docker: true
+      image-labels: |
+        org.opencontainers.image.title=ZuidWest FM Metadata
+        org.opencontainers.image.licenses=MIT
+    permissions:
+      contents: write
+      packages: write
+```
+
+Inputs: `project-name`, `ldflags-target`, `build-matrix` (JSON), `image-labels` (multiline), `enable-docker` (default `false`).
+
+### `docker-publish.yml` — reusable Docker build/push
+
+Called transitively by `go-release.yml` when `enable-docker: true`. Direct call only when a repo has its own release flow.
+
+Inputs: `version`, `image-name` (default `${{ github.repository }}`), `dockerfile-path` (default `Dockerfile`), `platforms` (default `linux/amd64,linux/arm64`), `image-labels`.
+
+## Maintenance contract
+
+- **Versioning:** semver. Minor for additive optional inputs, major for breaking changes (renamed/removed inputs, default changes that break consumers). Both an immutable `v1.x.y` and a moving `v1` tag exist; consumers pin to `@v1` to follow fixes, `@v1.x.y` to freeze.
+- **Bumps:** dependabot via `github-actions` ecosystem in this repo + each consumer.
+- **Phase 0 standards** (locked in): action major-pinning, `golangci-lint` pinned, race detection required (`-race -shuffle=on`), `:edge` Docker tag NOT published (artifacts only), `BUILD_TIME` from `date -u`, `provenance: false` and `sbom: false` (opt-in only).
+- **Drift before templating:** new copy-paste templates only after audiologger-style hand-alignment proves the shape on at least two consumers. Don't template a shape that hasn't stabilized.
 
 ## Troubleshooting
 
@@ -45,3 +103,4 @@ env:
 | Security scan fails | Dockerfile must be buildable |
 | Compose warning about env vars | Expected behavior, no action needed |
 | Shell workflow doesn't run | Only triggers on `.sh` changes |
+| Reusable workflow can't see secrets | `workflow_call` only forwards `GITHUB_TOKEN`; declare other secrets explicitly |

--- a/workflow-templates/docker-quality.yml
+++ b/workflow-templates/docker-quality.yml
@@ -45,9 +45,9 @@ jobs:
         id: check_dockerfile
         run: |
           if [ -f "${{ env.DOCKERFILE_PATH }}" ]; then
-            echo "has_dockerfile=true" >> $GITHUB_OUTPUT
+            echo "has_dockerfile=true" >> "$GITHUB_OUTPUT"
           else
-            echo "has_dockerfile=false" >> $GITHUB_OUTPUT
+            echo "has_dockerfile=false" >> "$GITHUB_OUTPUT"
           fi
 
       # Configuration in .hadolint.yaml - do NOT duplicate ignore rules here
@@ -83,9 +83,9 @@ jobs:
             fi
           done
           if [ -n "$COMPOSE_FILES" ]; then
-            echo "has_compose=true" >> $GITHUB_OUTPUT
+            echo "has_compose=true" >> "$GITHUB_OUTPUT"
           else
-            echo "has_compose=false" >> $GITHUB_OUTPUT
+            echo "has_compose=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Docker Compose Validation

--- a/workflow-templates/docker-security.yml
+++ b/workflow-templates/docker-security.yml
@@ -46,21 +46,20 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build Image for Scanning
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ${{ env.DOCKERFILE_PATH }}
           push: false
+          pull: true
           load: true
           tags: ${{ github.repository }}:scan
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
 
       - name: Cache Trivy DB
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/trivy
           key: trivy-db
@@ -69,7 +68,7 @@ jobs:
 
       # Includes MEDIUM for visibility in Security tab
       - name: Trivy SARIF Report
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: ${{ github.repository }}:scan
           format: 'sarif'
@@ -87,7 +86,7 @@ jobs:
           sarif_file: 'trivy-results.sarif'
 
       - name: Fail on Critical Vulnerabilities
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: ${{ github.repository }}:scan
           format: 'table'


### PR DESCRIPTION
Phase 2 of #1: extract the audiologger workflow standard into reusable workflows callable via `workflow_call`. Plus housekeeping: stale README references, sync `docker-security.yml` with consumer practice.

## Summary

- **README**: drop `cleanup-ghcr.yml` references (workflow was removed in 81ca572), add Phase 2 reusable workflow docs, document the versioning contract (mutable `v1` + immutable `v1.x.y`).
- **`workflow-templates/docker-security.yml`**: bring forward to consumer-current versions (buildx v3→v4, build-push v6→v7, cache v4→v5, trivy 0.35→0.36). Drop gha-cache pair in favor of `pull: true`.
- **`workflow-templates/docker-quality.yml`**: quote `$GITHUB_OUTPUT` (SC2086), no behavior change.
- **`.github/workflows/go-ci.yml`** (new): Go CI mirror of audiologger — race-detected tests, vet, fmt drift, pinned golangci-lint, deadcode/govulncheck/staticcheck. Optional Bun frontend job.
- **`.github/workflows/go-release.yml`** (new): tag re-run guard, prerelease auto-detect, build matrix from JSON, edge artifacts named `<project>-edge-<sha>`, optional docker chain.
- **`.github/workflows/docker-publish.yml`** (new): BUILD_TIME from `date -u`, `provenance: false`, `sbom: false`, semver tag emission, no `:edge` tag (artifacts-only per Phase 0).

Consumers stay on hand-aligned workflows until v1 stabilizes; flip to shims happens in a later cycle.

## Test plan

- [x] `actionlint .github/workflows/*.yml workflow-templates/*.yml` — clean
- [ ] After merge: tag `v1.0.0` (immutable) + `v1` (mutable major)
- [ ] After merge: smoke-test from a sibling consumer with `uses: oszuidwest/.github-templates/.github/workflows/go-ci.yml@v1`

Refs #1