### PR TITLE
docs: document packages:write requirement for go-release.yml callers

### DIFF
--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -13,6 +13,10 @@
 # - GitHub Release with prerelease auto-detect via contains(version, '-').
 # - Edge artifact: <project>-edge-<sha>, no Docker push for edge.
 # - Optional Docker publish for releases via docker-publish.yml.
+#
+# Caller permissions: contents: write AND packages: write are required, even
+# when enable-docker is false. GitHub validates nested reusable-workflow
+# permissions at parse time, regardless of the docker job's `if:` condition.
 
 name: Go Release
 

--- a/README.md
+++ b/README.md
@@ -78,10 +78,12 @@ jobs:
         org.opencontainers.image.licenses=MIT
     permissions:
       contents: write
-      packages: write
+      packages: write  # Required even with enable-docker: false (see below).
 ```
 
 Inputs: `project-name`, `ldflags-target`, `build-matrix` (JSON), `main-package` (default `.` — set to `./cmd/foo` for repos with a non-root main), `version` (forward `inputs.version` from the consumer's `workflow_dispatch`; leave empty for tag pushes), `image-labels` (multiline), `enable-docker` (default `false`).
+
+**Permissions caveat:** the caller must always declare `packages: write` even when `enable-docker: false`. GitHub validates nested reusable-workflow permissions at workflow-parse time, so the conditional `docker` job's permission requirement applies regardless of whether `if:` evaluates true. Symptom if missed: `Invalid workflow file ... The nested job 'docker' is requesting 'packages: write', but is only allowed 'packages: none'`.
 
 **LDFLAGS contract:** the workflow injects PascalCase symbols `Version`, `Commit`, `BuildTime` at the package path you pass in `ldflags-target`. The Go package must declare those exact identifiers (e.g. `var Version, Commit, BuildTime string`). Lowercase names (`version`, `buildTime`) are not patched.
 
@@ -121,3 +123,4 @@ Inputs: `version` (required, must be non-empty and not `edge` — the workflow r
 | Compose warning about env vars | Expected behavior, no action needed |
 | Shell workflow doesn't run | Only triggers on `.sh` changes |
 | Reusable workflow can't see secrets | `workflow_call` only forwards `GITHUB_TOKEN`; declare other secrets explicitly |
+| `go-release.yml` rejects with "nested job 'docker' is requesting 'packages: write'" | Caller must declare `packages: write` even when `enable-docker: false` (parse-time validation) |


### PR DESCRIPTION
## Summary

- Smoke test on a real consumer (`zwfm-babbel`) revealed that callers of `go-release.yml@v1` must declare `packages: write` even when `enable-docker: false`.
- Root cause: GitHub validates nested reusable-workflow permissions at workflow-parse time, regardless of the conditional `if:` on the nested job.
- Symptom: `Invalid workflow file ... The nested job 'docker' is requesting 'packages: write', but is only allowed 'packages: none'`.
- Doc-only change. No behavioral effect on existing consumers (the example in README already declares `packages: write`).

## Changes

- `README.md`: inline comment on the example, dedicated **Permissions caveat** paragraph, troubleshooting row.
- `.github/workflows/go-release.yml`: header comment block notes the requirement.

## Test plan

- [x] `actionlint` clean
- [x] Smoke test on `zwfm-babbel` (`smoke-test/v1-consumer`) confirmed the build path with `main-package: ./cmd/babbel` works once `packages: write` is granted (run 25568411540 — steps 1-10 pass; step 11 failure is push-event artifact unrelated to permissions).