### PR TITLE
feat(go-release): add release-body input (v1.1.0)

### DIFF
--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -64,6 +64,13 @@ on:
         description: 'Docker platforms passed through to docker-publish.yml.'
         type: string
         default: 'linux/amd64,linux/arm64'
+      release-body:
+        description: >-
+          Optional release-notes prefix prepended to auto-generated notes.
+          Supports markdown. Use for Docker pull commands, install instructions,
+          etc. When empty, only auto-generated notes are used.
+        type: string
+        default: ''
 
 jobs:
   release:
@@ -179,6 +186,9 @@ jobs:
         with:
           tag_name: ${{ steps.version.outputs.version }}
           files: dist/*
+          # When body is non-empty, softprops/action-gh-release prepends it to
+          # the auto-generated notes. Empty body falls through to auto-only.
+          body: ${{ inputs.release-body }}
           generate_release_notes: true
           draft: false
           prerelease: ${{ contains(steps.version.outputs.version, '-') }}

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ jobs:
       packages: write  # Required even with enable-docker: false (see below).
 ```
 
-Inputs: `project-name`, `ldflags-target`, `build-matrix` (JSON), `main-package` (default `.` — set to `./cmd/foo` for repos with a non-root main), `version` (forward `inputs.version` from the consumer's `workflow_dispatch`; leave empty for tag pushes), `image-labels` (multiline), `enable-docker` (default `false`).
+Inputs: `project-name`, `ldflags-target`, `build-matrix` (JSON), `main-package` (default `.` — set to `./cmd/foo` for repos with a non-root main), `version` (forward `inputs.version` from the consumer's `workflow_dispatch`; leave empty for tag pushes), `image-labels` (multiline), `enable-docker` (default `false`), `release-body` (optional markdown prepended to auto-generated release notes — handy for Docker pull commands or install instructions).
 
 **Permissions caveat:** the caller must always declare `packages: write` even when `enable-docker: false`. GitHub validates nested reusable-workflow permissions at workflow-parse time, so the conditional `docker` job's permission requirement applies regardless of whether `if:` evaluates true. Symptom if missed: `Invalid workflow file ... The nested job 'docker' is requesting 'packages: write', but is only allowed 'packages: none'`.
 


### PR DESCRIPTION
## Summary

Adds an optional `release-body` input to `go-release.yml`. When non-empty, it's passed to `softprops/action-gh-release@v3` as `body:`, which prepends it to the auto-generated release notes.

## Why

Consumers (metadata, babbel, encoder) currently include a custom intro in their release body — Docker pull commands, install instructions, etc. Without this input, migrating them to thin shims using `go-release.yml@v1` would lose that surface-level content.

Example after migration (zwfm-encoder shim):

\`\`\`yaml
jobs:
  release:
    uses: oszuidwest/.github-templates/.github/workflows/go-release.yml@v1
    with:
      project-name: encoder
      release-body: |
        ## Installation
        On Raspberry Pi 4/5 with HiFiBerry card:
        \`\`\`bash
        sudo /bin/bash -c \"$(curl -fsSL ...install.sh)\"
        \`\`\`
\`\`\`

## Maintenance contract

Per [README](https://github.com/oszuidwest/.github-templates/blob/main/README.md#maintenance-contract): additive optional input → minor bump (v1.0.0 → v1.1.0). The moving `v1` tag will be advanced after merge; existing pinning to `@v1.0.0` remains immutable.

## Test plan

- [x] `actionlint .github/workflows/go-release.yml` clean
- [ ] After merge: tag `v1.1.0` and move `v1` forward
- [ ] First consumer to validate: zwfm-metadata migration PR will exercise this input with a Docker-pull body