### PR TITLE
fix: derive COMMIT from HEAD after tag checkout

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -75,6 +75,13 @@ jobs:
         id: build_time
         run: echo "value=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
 
+      - name: Resolve commit SHA
+        id: commit
+        # Use HEAD, not github.sha. On workflow_dispatch the previous step
+        # checks out the version tag; github.sha still points at the
+        # dispatch-commit and would label the image with the wrong commit.
+        run: echo "value=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
       - name: Resolve image name
         id: image
         env:
@@ -125,5 +132,5 @@ jobs:
           sbom: false
           build-args: |
             VERSION=${{ inputs.version }}
-            COMMIT=${{ github.sha }}
+            COMMIT=${{ steps.commit.outputs.value }}
             BUILD_TIME=${{ steps.build_time.outputs.value }}

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -154,13 +154,17 @@ jobs:
       - name: Build binaries
         env:
           VERSION: ${{ steps.version.outputs.version }}
-          COMMIT: ${{ github.sha }}
           PROJECT: ${{ inputs.project-name }}
           LDFLAGS_TARGET: ${{ inputs.ldflags-target }}
           BUILD_MATRIX: ${{ inputs.build-matrix }}
           MAIN_PACKAGE: ${{ inputs.main-package }}
         run: |
           mkdir -p dist
+          # Resolve COMMIT from HEAD, not github.sha. After a manual re-run on
+          # an existing tag the previous step checks out the tag commit; the
+          # workflow-level github.sha still points at the dispatch-commit and
+          # would yield a binary whose embedded commit doesn't match the tag.
+          COMMIT=$(git rev-parse HEAD)
           BUILD_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
           echo "$BUILD_MATRIX" | jq -c '.[]' | while read -r entry; do


### PR DESCRIPTION
## Summary
- `go-release.yml` and `docker-publish.yml` resolve the embedded `COMMIT` ldflag and Docker build-arg from `github.sha`. Both files have a tag-checkout step that runs first on `workflow_dispatch` (`git checkout refs/tags/$VERSION`), but `github.sha` is workflow-level and still points at the **dispatch-commit**.
- For `workflow_dispatch` re-runs of an **existing** tag from a newer main, this means the binary contents come from the tag (correct) but `Commit` ldflag / image label points at an unrelated commit on main.
- Fix: resolve `COMMIT=$(git rev-parse HEAD)` after checkout. Tag-push events are unaffected (HEAD == github.sha == tag commit).

## Why now
Round 2 added the tag-checkout invariant for binary/image source consistency, but the metadata stayed wired to `github.sha`. Caught in cross-review post-migration.

## Test plan
- [x] go-release.yml `Build binaries` step computes `COMMIT` inside the `run:` block (after the tag-checkout step has run)
- [x] docker-publish.yml has new `Resolve commit SHA` step (id `commit`); build-args reference `steps.commit.outputs.value` instead of `github.sha`
- [ ] CI on this branch (no consumer-affecting changes; templates have no integration tests of their own)
- [ ] Post-merge: tag `v1.1.1` and force-push `v1` → next consumer release will exercise both paths