### PR TITLE
fix: fail go-ci on dead code findings

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -66,7 +66,12 @@ jobs:
           args: --timeout=5m
 
       - name: Check for dead code
-        run: go tool deadcode ./...
+        run: |
+          deadcode_output=$(go tool deadcode ./...)
+          if [ -n "$deadcode_output" ]; then
+            echo "$deadcode_output"
+            exit 1
+          fi
 
       - name: Run govulncheck
         run: go tool govulncheck ./...


### PR DESCRIPTION
## Summary
- `go tool deadcode` exits 0 even when it finds dead code — it only prints to stdout. The current `Check for dead code` step in `go-ci.yml` therefore never fails CI, defeating its purpose.
- Wrap the invocation: capture output, exit 1 when non-empty. Mirrors the audiologger/babbel Makefile pattern that has been correctly failing on findings in those projects all along.

## Risk
Consumers (`audiologger`, `metadata`, `encoder`) using `go-ci.yml@v1` will start failing on next CI run if they have undetected dead code. That's the intended behavior — the previous step gave a false-green signal.

## Test plan
- [x] Diff is minimal (5-line wrapper around the same command)
- [ ] No CI on this PR (templates are workflow_call only)
- [ ] Post-merge: monitor next consumer CI runs for surfaced findings (treat as real, not a regression)