### PR TITLE
chore(release): default workflow permissions to read

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -12,7 +12,7 @@
 
 name: Docker Publish
 
-on:
+'on':
   workflow_call:
     inputs:
       version:
@@ -20,7 +20,9 @@ on:
         type: string
         required: true
       image-name:
-        description: 'Image name. Defaults to the calling repository (github.repository) when empty.'
+        description: >-
+          Image name. Defaults to the calling repository
+          (github.repository) when empty.
         type: string
         default: ''
       dockerfile-path:
@@ -52,7 +54,7 @@ jobs:
           VERSION: ${{ inputs.version }}
         run: |
           if [ -z "$VERSION" ] || [ "$VERSION" = "edge" ]; then
-            echo "::error::docker-publish.yml does not accept empty or 'edge' versions (Phase 0: edge is artifacts-only)."
+            echo "::error::docker-publish.yml requires a release version."
             exit 1
           fi
 
@@ -109,8 +111,8 @@ jobs:
         uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}
-          # type=semver patterns extract from values starting with 'v' (e.g. v1.2.3 -> 1.2.3).
-          # Pre-release tags (v1.0.0-rc1) only emit {{version}}; latest/major/minor are skipped.
+          # type=semver patterns extract from v-prefixed versions.
+          # Pre-releases skip latest/major/minor tags.
           tags: |
             type=semver,pattern={{version}},value=${{ inputs.version }}
             type=semver,pattern={{major}}.{{minor}},value=${{ inputs.version }}

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -10,7 +10,7 @@
 
 name: Go CI
 
-on:
+'on':
   workflow_call:
     inputs:
       golangci-lint-version:
@@ -26,7 +26,9 @@ on:
         type: boolean
         default: false
       frontend-tool:
-        description: 'Frontend tool to use when enable-frontend is true. Only "bun" is supported in v1.'
+        description: >-
+          Frontend tool to use when enable-frontend is true.
+          Only "bun" is supported in v1.
         type: string
         default: 'bun'
 
@@ -84,7 +86,7 @@ jobs:
       - name: Verify frontend tool
         if: inputs.frontend-tool != 'bun'
         run: |
-          echo "::error::frontend-tool '${{ inputs.frontend-tool }}' is not supported in v1. Only 'bun' is implemented."
+          echo "::error::Only frontend-tool 'bun' is supported in v1."
           exit 1
 
       - uses: oven-sh/setup-bun@v2

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -6,10 +6,11 @@
 # - Tag push or workflow_call with `version: edge` or `vX.Y.Z` (or `X.Y.Z`).
 # - Tag re-run guard so workflow_dispatch can be re-run on existing tags.
 #   When a tag already exists, that tag is checked out so the build matches
-#   the tag (no asset/image divergence between release.yml and docker-publish.yml).
+#   the tag.
 # - Race-detected tests with shuffle.
 # - Tests run BEFORE tag creation (fail-fast on a manual dispatch).
-# - Build matrix from JSON input, ldflags inject PascalCase Version/Commit/BuildTime.
+# - Build matrix from JSON input.
+# - Ldflags inject PascalCase Version/Commit/BuildTime.
 # - GitHub Release with prerelease auto-detect via contains(version, '-').
 # - Edge artifact: <project>-edge-<sha>, no Docker push for edge.
 # - Optional Docker publish for releases via docker-publish.yml.
@@ -20,11 +21,12 @@
 
 name: Go Release
 
-on:
+'on':
   workflow_call:
     inputs:
       project-name:
-        description: 'Project name. Used as edge artifact prefix and binary basename.'
+        description: >-
+          Project name. Used as edge artifact prefix and binary basename.
         type: string
         required: true
       ldflags-target:
@@ -35,7 +37,9 @@ on:
         type: string
         required: true
       build-matrix:
-        description: 'JSON array of build targets, e.g. [{"os":"linux","arch":"amd64"},{"os":"linux","arch":"arm","arm":"7"}].'
+        description: >-
+          JSON array of build targets, e.g.
+          [{"os":"linux","arch":"amd64"},{"os":"linux","arch":"arm"}].
         type: string
         required: true
       main-package:
@@ -53,7 +57,8 @@ on:
         type: boolean
         default: false
       image-labels:
-        description: 'Multiline image labels passed through to docker-publish.yml.'
+        description: >-
+          Multiline image labels passed through to docker-publish.yml.
         type: string
         default: ''
       dockerfile-path:
@@ -71,6 +76,9 @@ on:
           etc. When empty, only auto-generated notes are used.
         type: string
         default: ''
+
+permissions:
+  contents: read
 
 jobs:
   release:
@@ -97,9 +105,10 @@ jobs:
           INPUT_VERSION: ${{ inputs.version }}
           EVENT_NAME: ${{ github.event_name }}
         run: |
-          if [ "$EVENT_NAME" = "workflow_call" ] || [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+          if [ "$EVENT_NAME" = "workflow_call" ] ||
+             [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             if [ -z "$INPUT_VERSION" ]; then
-              echo "::error::version input is required when invoked via workflow_call/workflow_dispatch."
+              echo "::error::version input is required for manual calls."
               exit 1
             fi
             if [ "$INPUT_VERSION" = "edge" ]; then
@@ -135,14 +144,16 @@ jobs:
           git diff --exit-code
 
       - name: Create or check out version tag (manual release)
-        if: github.event_name != 'push' && steps.version.outputs.is_release == 'true'
+        if: >-
+          github.event_name != 'push' &&
+          steps.version.outputs.is_release == 'true'
         env:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           if git rev-parse -q --verify "refs/tags/$VERSION" >/dev/null; then
-            echo "Tag $VERSION already exists; checking it out so the build matches the tag."
+            echo "Tag $VERSION already exists; checking out that tag."
           else
             git tag "$VERSION"
             git push origin "refs/tags/$VERSION"
@@ -178,8 +189,14 @@ jobs:
 
             echo "Building $output_name"
 
-            env GOOS="$GOOS" GOARCH="$GOARCH" GOARM="$GOARM" CGO_ENABLED=0 go build \
-              -ldflags="-s -w -X ${LDFLAGS_TARGET}.Version=${VERSION} -X ${LDFLAGS_TARGET}.Commit=${COMMIT} -X ${LDFLAGS_TARGET}.BuildTime=${BUILD_TIME}" \
+            LDFLAGS="-s -w"
+            LDFLAGS="$LDFLAGS -X ${LDFLAGS_TARGET}.Version=${VERSION}"
+            LDFLAGS="$LDFLAGS -X ${LDFLAGS_TARGET}.Commit=${COMMIT}"
+            LDFLAGS="$LDFLAGS -X ${LDFLAGS_TARGET}.BuildTime=${BUILD_TIME}"
+
+            env GOOS="$GOOS" GOARCH="$GOARCH" GOARM="$GOARM" CGO_ENABLED=0 \
+              go build \
+              -ldflags="$LDFLAGS" \
               -o "dist/${output_name}" \
               "${MAIN_PACKAGE}"
           done
@@ -209,7 +226,10 @@ jobs:
 
   docker:
     needs: release
-    if: inputs.enable-docker && needs.release.outputs.is_release == 'true' && needs.release.result == 'success'
+    if: >-
+      inputs.enable-docker &&
+      needs.release.outputs.is_release == 'true' &&
+      needs.release.result == 'success'
     uses: ./.github/workflows/docker-publish.yml
     with:
       version: ${{ needs.release.outputs.version }}

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ on:
   workflow_dispatch:
     inputs:
       version: { description: 'Version to build', required: true, default: 'edge' }
+permissions:
+  contents: read
 jobs:
   release:
     uses: oszuidwest/.github-templates/.github/workflows/go-release.yml@v1
@@ -83,7 +85,7 @@ jobs:
 
 Inputs: `project-name`, `ldflags-target`, `build-matrix` (JSON), `main-package` (default `.` — set to `./cmd/foo` for repos with a non-root main), `version` (forward `inputs.version` from the consumer's `workflow_dispatch`; leave empty for tag pushes), `image-labels` (multiline), `enable-docker` (default `false`), `release-body` (optional markdown prepended to auto-generated release notes — handy for Docker pull commands or install instructions).
 
-**Permissions caveat:** the caller must always declare `packages: write` even when `enable-docker: false`. GitHub validates nested reusable-workflow permissions at workflow-parse time, so the conditional `docker` job's permission requirement applies regardless of whether `if:` evaluates true. Symptom if missed: `Invalid workflow file ... The nested job 'docker' is requesting 'packages: write', but is only allowed 'packages: none'`.
+**Permissions caveat:** keep the caller workflow default at `contents: read`, then grant `contents: write` and `packages: write` only on the reusable release job. The caller job must always declare `packages: write` even when `enable-docker: false`. GitHub validates nested reusable-workflow permissions at workflow-parse time, so the conditional `docker` job's permission requirement applies regardless of whether `if:` evaluates true. Symptom if missed: `Invalid workflow file ... The nested job 'docker' is requesting 'packages: write', but is only allowed 'packages: none'`.
 
 **LDFLAGS contract:** the workflow injects PascalCase symbols `Version`, `Commit`, `BuildTime` at the package path you pass in `ldflags-target`. The Go package must declare those exact identifiers (e.g. `var Version, Commit, BuildTime string`). Lowercase names (`version`, `buildTime`) are not patched.
 

--- a/config-templates/dependabot.yml
+++ b/config-templates/dependabot.yml
@@ -23,47 +23,47 @@ updates:
       interval: "weekly"
       day: "monday"
 
-  # ============================================================================
-  # LANGUAGE-SPECIFIC ECOSYSTEMS
-  # Uncomment the sections relevant to your project
-  # ============================================================================
+# ============================================================================
+# LANGUAGE-SPECIFIC ECOSYSTEMS
+# Uncomment the sections relevant to your project
+# ============================================================================
 
-  # Go modules
-  # - package-ecosystem: "gomod"
-  #   directory: "/"
-  #   schedule:
-  #     interval: "weekly"
-  #     day: "monday"
-  #   groups:
-  #     all-dependencies:
-  #       patterns:
-  #         - "*"
+# Go modules
+# - package-ecosystem: "gomod"
+#   directory: "/"
+#   schedule:
+#     interval: "weekly"
+#     day: "monday"
+#   groups:
+#     all-dependencies:
+#       patterns:
+#         - "*"
 
-  # Node.js / npm
-  # - package-ecosystem: "npm"
-  #   directory: "/"
-  #   schedule:
-  #     interval: "weekly"
-  #     day: "monday"
-  #   groups:
-  #     all-dependencies:
-  #       patterns:
-  #         - "*"
+# Node.js / npm
+# - package-ecosystem: "npm"
+#   directory: "/"
+#   schedule:
+#     interval: "weekly"
+#     day: "monday"
+#   groups:
+#     all-dependencies:
+#       patterns:
+#         - "*"
 
-  # Python / pip
-  # - package-ecosystem: "pip"
-  #   directory: "/"
-  #   schedule:
-  #     interval: "weekly"
-  #     day: "monday"
+# Python / pip
+# - package-ecosystem: "pip"
+#   directory: "/"
+#   schedule:
+#     interval: "weekly"
+#     day: "monday"
 
-  # Rust / Cargo
-  # - package-ecosystem: "cargo"
-  #   directory: "/"
-  #   schedule:
-  #     interval: "weekly"
-  #     day: "monday"
-  #   groups:
-  #     all-dependencies:
-  #       patterns:
-  #         - "*"
+# Rust / Cargo
+# - package-ecosystem: "cargo"
+#   directory: "/"
+#   schedule:
+#     interval: "weekly"
+#     day: "monday"
+#   groups:
+#     all-dependencies:
+#       patterns:
+#         - "*"

--- a/workflow-templates/docker-quality.yml
+++ b/workflow-templates/docker-quality.yml
@@ -2,19 +2,19 @@
 # Docker Quality Workflow Template
 # Source: oszuidwest/.github-templates
 #
-# This workflow lints Dockerfiles, validates YAML, and checks Docker Compose files.
+# This workflow lints Dockerfiles, YAML, and Docker Compose files.
 # Copy to: .github/workflows/docker-quality.yml
 #
 # Required config files:
 #   - .hadolint.yaml (at repo root)
 #
 # Customization:
-#   - DOCKERFILE_PATH: Change if Dockerfile is not at root (e.g., "docker/Dockerfile")
+#   - DOCKERFILE_PATH: Change if Dockerfile is not at root
 #   - Adjust YAML lint rules in the inline config as needed
 
 name: Docker Quality
 
-on:
+'on':
   push:
     branches: [main]
   pull_request:
@@ -77,7 +77,12 @@ jobs:
         id: check_compose
         run: |
           COMPOSE_FILES=""
-          for f in docker-compose.yml docker-compose.yaml compose.yml compose.yaml; do
+            for f in \
+              docker-compose.yml \
+              docker-compose.yaml \
+              compose.yml \
+              compose.yaml
+            do
             if [ -f "$f" ]; then
               COMPOSE_FILES="$COMPOSE_FILES $f"
             fi
@@ -97,7 +102,7 @@ jobs:
           if ! OUTPUT=$(docker compose config --quiet 2>&1); then
             # Missing env vars = warning, syntax errors = fail
             if echo "$OUTPUT" | grep -qi "variable is not set"; then
-              echo "::warning::Docker Compose validation requires environment variables: $OUTPUT"
+                echo "::warning::Compose env vars missing: $OUTPUT"
             else
               echo "::error::Docker Compose validation failed: $OUTPUT"
               exit 1

--- a/workflow-templates/docker-security.yml
+++ b/workflow-templates/docker-security.yml
@@ -13,7 +13,7 @@
 
 name: Docker Security
 
-on:
+'on':
   push:
     branches: [main]
   pull_request:

--- a/workflow-templates/shell-quality.yml
+++ b/workflow-templates/shell-quality.yml
@@ -12,7 +12,7 @@
 
 name: Shell Quality
 
-on:
+'on':
   push:
     branches: [main]
     paths:


### PR DESCRIPTION
## Summary
- set the reusable Go release workflow default token permission to `contents: read`
- document the caller pattern: workflow-level read, release job write
- clean up existing YAML style issues so the repository validation command is green

## Validation
- `git diff --check`
- `yamllint .github/workflows/*.yml workflow-templates/*.yml config-templates/*.yml config-templates/.hadolint.yaml`
- `actionlint .github/workflows/*.yml workflow-templates/*.yml`