### PR TITLE
docs: show full trigger context in docker-publish example

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,14 +113,18 @@ Inputs:
 
 ### `docker-publish.yml` — reusable Docker build/push
 
-Called transitively by `go-release.yml` when `enable-docker: true`. Direct call only when a repo has its own release flow:
+Called transitively by `go-release.yml` when `enable-docker: true`. Direct call only when a repo has its own release flow. Trigger from a tag push so `github.ref_name` resolves to the tag — empty values and `edge` are rejected by the workflow:
 
 ```yaml
+name: Publish Docker
+on:
+  push: { tags: ['v*'] }
+permissions: { contents: read }
 jobs:
   publish:
     uses: oszuidwest/.github-templates/.github/workflows/docker-publish.yml@v1
     with:
-      version: ${{ github.ref_name }}  # only call from a tag push or after tagging
+      version: ${{ github.ref_name }}
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
## Summary
- The direct-invocation example for `docker-publish.yml` was the only reusable-workflow example without `name:`, `on:`, and workflow-level `permissions:` blocks.
- It relied on an inline comment (\`# only call from a tag push or after tagging\`) to convey that \`github.ref_name\` needs a tag-push trigger; a reader copying the example into a \`workflow_dispatch\` would hit the empty/edge rejection in the workflow's validation step.
- Now matches the structure of the go-ci and go-release examples.

## Validation
- \`git diff --check\` — clean
- README content cross-referenced against \`docker-publish.yml\` validation step (lines 52-59): empty/edge values are indeed rejected, so the new prose is accurate.