### PR TITLE
chore: sync workflow templates with consumer-canonical version

### DIFF
--- a/workflow-templates/docker-quality.yml
+++ b/workflow-templates/docker-quality.yml
@@ -2,19 +2,19 @@
 # Docker Quality Workflow Template
 # Source: oszuidwest/.github-templates
 #
-# This workflow lints Dockerfiles, YAML, and Docker Compose files.
+# This workflow lints Dockerfiles, validates YAML, and checks Docker Compose files.
 # Copy to: .github/workflows/docker-quality.yml
 #
 # Required config files:
 #   - .hadolint.yaml (at repo root)
 #
 # Customization:
-#   - DOCKERFILE_PATH: Change if Dockerfile is not at root
+#   - DOCKERFILE_PATH: Change if Dockerfile is not at root (e.g., "docker/Dockerfile")
 #   - Adjust YAML lint rules in the inline config as needed
 
 name: Docker Quality
 
-'on':
+on:
   push:
     branches: [main]
   pull_request:
@@ -77,12 +77,7 @@ jobs:
         id: check_compose
         run: |
           COMPOSE_FILES=""
-            for f in \
-              docker-compose.yml \
-              docker-compose.yaml \
-              compose.yml \
-              compose.yaml
-            do
+          for f in docker-compose.yml docker-compose.yaml compose.yml compose.yaml; do
             if [ -f "$f" ]; then
               COMPOSE_FILES="$COMPOSE_FILES $f"
             fi
@@ -102,7 +97,7 @@ jobs:
           if ! OUTPUT=$(docker compose config --quiet 2>&1); then
             # Missing env vars = warning, syntax errors = fail
             if echo "$OUTPUT" | grep -qi "variable is not set"; then
-                echo "::warning::Compose env vars missing: $OUTPUT"
+              echo "::warning::Docker Compose validation requires environment variables: $OUTPUT"
             else
               echo "::error::Docker Compose validation failed: $OUTPUT"
               exit 1

--- a/workflow-templates/shell-quality.yml
+++ b/workflow-templates/shell-quality.yml
@@ -12,7 +12,7 @@
 
 name: Shell Quality
 
-'on':
+on:
   push:
     branches: [main]
     paths:


### PR DESCRIPTION
## Summary

- Forward-sync `workflow-templates/docker-quality.yml` and `workflow-templates/shell-quality.yml` to the version that already lives in the consumers (metadata, audiologger, babbel, encoder).
- The Round 2 alignment work improved the consumer files but the templates were left behind — a fresh `cp workflow-templates/...` today would regress to the stale shape.

## What changed

| File | Change |
|------|--------|
| `docker-quality.yml` | Drop `'on':` quoting; clearer header + DOCKERFILE_PATH comment; single-line compose probe; longer env-var warning |
| `shell-quality.yml` | Drop `'on':` quoting (only diff with consumers) |

Babbel-specific `ignore: openapi.yaml` is **not** brought back into the template — that's project-specific (OpenAPI tooling owns that file).

## Verification

```sh
diff <(gh api /repos/oszuidwest/zwfm-metadata/contents/.github/workflows/docker-quality.yml --jq '.content' | base64 -d) workflow-templates/docker-quality.yml
diff <(gh api /repos/oszuidwest/zwfm-encoder/contents/.github/workflows/shell-quality.yml --jq '.content' | base64 -d) workflow-templates/shell-quality.yml
```

Both produce empty output (template byte-identical to consumer canonical).

## Test plan

- [x] Diff against consumer canonical = empty
- [ ] No version bump required (copy-paste templates have no semver — change applies on next `cp`)
- [ ] Existing consumers are already on the new shape, so no consumer-side action