### PR TITLE
feat(release): trust-main model — drop inline tests/lint/fmt

### DIFF
--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -2,13 +2,16 @@
 # Reusable Go release workflow
 # Source: oszuidwest/.github-templates
 #
-# Mirrors the audiologger release standard:
+# Trust-main release model: this workflow builds binaries from the tagged
+# commit and ships them. Verification (tests, lint, fmt) is the job of PR CI
+# on the way into main, not the release path. To gate a release on a custom
+# check (integration tests, smoke tests, etc.), compose via `needs:` from the
+# caller — see the README for the pattern.
+#
 # - Tag push or workflow_call with `version: edge` or `vX.Y.Z` (or `X.Y.Z`).
 # - Tag re-run guard so workflow_dispatch can be re-run on existing tags.
 #   When a tag already exists, that tag is checked out so the build matches
 #   the tag.
-# - Race-detected tests with shuffle.
-# - Tests run BEFORE tag creation (fail-fast on a manual dispatch).
 # - Build matrix from JSON input.
 # - Ldflags inject PascalCase Version/Commit/BuildTime.
 # - GitHub Release with prerelease auto-detect via contains(version, '-').
@@ -131,17 +134,6 @@ jobs:
 
       - name: Download dependencies
         run: go mod download
-
-      - name: Run tests
-        run: go test -race -shuffle=on -v ./...
-
-      - name: Run go vet
-        run: go vet ./...
-
-      - name: Check formatting
-        run: |
-          go fmt ./...
-          git diff --exit-code
 
       - name: Create or check out version tag (manual release)
         if: >-

--- a/README.md
+++ b/README.md
@@ -140,6 +140,40 @@ Inputs:
 | `platforms` | string | no | `linux/amd64,linux/arm64` | Comma-separated Docker buildx platforms. |
 | `image-labels` | string | no | `''` | Multiline OCI labels passed to metadata/build. |
 
+### Composing custom pre-release gates
+
+`go-release.yml` is build-and-ship only — it does not run tests, lint, or fmt. The assumption is that PR CI already gated the merge into main, so a tag on main is releasable by construction. This is the standard "trust main" model: don't repeat verification work in the release path.
+
+If a consumer needs an extra pre-release check that PR CI doesn't cover (integration tests against a live service, smoke tests, etc.), gate the release on it via `needs:` instead of asking the template to grow another input:
+
+```yaml
+name: Release
+on:
+  push: { tags: ['v*'] }
+  workflow_dispatch:
+    inputs:
+      version: { description: 'Version to build', required: true, default: 'edge' }
+permissions:
+  contents: read
+jobs:
+  pre-release:
+    uses: ./.github/workflows/integration-test.yml
+
+  release:
+    needs: pre-release
+    uses: oszuidwest/.github-templates/.github/workflows/go-release.yml@v1
+    with:
+      project-name: my-service
+      ldflags-target: github.com/org/my-service/version
+      build-matrix: '[{"os":"linux","arch":"amd64"}]'
+      version: ${{ inputs.version }}
+    permissions:
+      contents: write
+      packages: write
+```
+
+The custom job lives in the consumer repo, the template stays small, and `needs:` short-circuits the release if the gate fails.
+
 ## Maintenance contract
 
 - **Versioning:** semver. Patch for compatible bug fixes and documentation clarifications, minor for additive optional inputs, major for breaking changes (renamed/removed inputs, permission model changes, or default changes that break consumers). Both an immutable `v1.x.y` and a moving `v1` tag exist; consumers pin to `@v1` to follow fixes, `@v1.x.y` to freeze.


### PR DESCRIPTION
## Summary

`go-release.yml` is now build-and-ship only. The inline `go test`, `go vet`, and `go fmt + git diff` steps are removed. PR CI on the way into main already gates correctness — repeating the work in the release path adds latency without changing outcomes (a tag on main is releasable by construction).

Consumers that need an extra pre-release check (integration tests, smoke tests, end-to-end) compose via `needs:` from their own caller workflow:

```yaml
jobs:
  pre-release:
    uses: ./.github/workflows/integration-test.yml
  release:
    needs: pre-release
    uses: oszuidwest/.github-templates/.github/workflows/go-release.yml@v1
    with: { ... }
    permissions:
      contents: write
      packages: write
```

The pattern is documented in the README under "Composing custom pre-release gates".

## Changes

- `.github/workflows/go-release.yml`: drop `Run tests`, `Run go vet`, `Check formatting` steps. Reword header comment from "Mirrors the audiologger release standard" to the trust-main framing.
- `README.md`: insert "Composing custom pre-release gates" section between the `docker-publish.yml` table and the Maintenance contract.

## Versioning

Minor bump (`v1.2.0`). No input or permission contract changes for existing consumers — the workflow simply does less verification work. Consumers that were relying on the embedded test step as their *only* test gate (none currently are; all four Go services have a separate CI workflow) would need to add their own pre-release `needs:` shim, which is the documented pattern.

## Test plan

- [x] `actionlint .github/workflows/go-release.yml` — clean
- [ ] After merge: tag `v1.2.0` and move `v1`, then verify a downstream release run still produces the expected artifacts
- [ ] Follow-up: aerontoolbox release.yml gets a thin shim using the composition pattern (issue #14, Step 2)