### PR TITLE
chore: drop 'on:' quoting across all reusable workflows + templates

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -12,7 +12,7 @@
 
 name: Docker Publish
 
-'on':
+on:
   workflow_call:
     inputs:
       version:

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -10,7 +10,7 @@
 
 name: Go CI
 
-'on':
+on:
   workflow_call:
     inputs:
       golangci-lint-version:

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -24,7 +24,7 @@
 
 name: Go Release
 
-'on':
+on:
   workflow_call:
     inputs:
       project-name:

--- a/workflow-templates/docker-security.yml
+++ b/workflow-templates/docker-security.yml
@@ -13,7 +13,7 @@
 
 name: Docker Security
 
-'on':
+on:
   push:
     branches: [main]
   pull_request:


### PR DESCRIPTION
## Summary

Drop the legacy `'on':` (YAML 1.1 truthy quoting) on every reusable workflow and template in this repo. After this PR every workflow uses the canonical unquoted `on:` form that GitHub's Actions docs recommend.

Files touched:
- `workflow-templates/docker-security.yml` (was the last template still on `'on':` — original scope)
- `.github/workflows/go-release.yml`
- `.github/workflows/go-ci.yml`
- `.github/workflows/docker-publish.yml`

`workflow-templates/docker-quality.yml` and `workflow-templates/shell-quality.yml` were already unquoted (#13).

Why unquoted `on:` is fine here even though yamllint's default warns about it: `docker-quality.yml`'s inline yamllint config has `truthy: allowed-values: ['true', 'false', 'on', 'off', 'yes', 'no']`, so consumers running our lint don't see truthy violations on `on:`.

## Test plan

- [x] `actionlint .github/workflows/*.yml workflow-templates/*.yml` — clean
- [x] All four touched files diff to a single-line `-'on':` / `+on:` change

## Versioning

No tag bump for the template files (`workflow-templates/`) — those are copy-paste, not pinned.

The reusable workflows under `.github/workflows/` (go-release.yml, go-ci.yml, docker-publish.yml) get the change rolled forward to `v1` after merge as a follow-up tag move (no behavior change, no API change — pure cosmetic).