### PR TITLE
chore: trim verbose comments in templates and reusable workflows

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,15 +1,5 @@
 ---
-# Reusable Docker publish workflow
-# Source: oszuidwest/.github-templates
-#
-# Mirrors the audiologger Docker standard:
-# - Builds for stable + prerelease tags. Edge is artifacts-only (Phase 0); this
-#   workflow does not emit `:edge` Docker tags.
-# - BUILD_TIME computed at run time (UTC ISO-8601).
-# - provenance: false, sbom: false (opt in via fork if needed).
-# - For workflow_dispatch with an existing version tag, checks out that tag so
-#   the image source matches the label.
-
+# Edge is artifacts-only — this workflow rejects empty/edge versions.
 name: Docker Publish
 
 on:
@@ -63,10 +53,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      # When triggered by tag push, the chain is already at the tagged commit.
-      # When triggered by workflow_dispatch, the entry workflow ran on a branch
-      # and a tag was just created upstream — check that tag out so the image
-      # source matches the version label.
+      # workflow_dispatch starts on a branch; align with the tag commit.
       - name: Check out version tag (manual dispatch)
         if: github.event_name == 'workflow_dispatch'
         env:
@@ -79,9 +66,7 @@ jobs:
 
       - name: Resolve commit SHA
         id: commit
-        # Use HEAD, not github.sha. On workflow_dispatch the previous step
-        # checks out the version tag; github.sha still points at the
-        # dispatch-commit and would label the image with the wrong commit.
+        # HEAD, not github.sha: previous step may have checked out the tag.
         run: echo "value=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Resolve image name
@@ -111,8 +96,7 @@ jobs:
         uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}
-          # type=semver patterns extract from v-prefixed versions.
-          # Pre-releases skip latest/major/minor tags.
+          # type=semver strips v-prefix; latest/major/minor skipped for prereleases.
           tags: |
             type=semver,pattern={{version}},value=${{ inputs.version }}
             type=semver,pattern={{major}}.{{minor}},value=${{ inputs.version }}

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -1,13 +1,4 @@
 ---
-# Reusable Go CI workflow
-# Source: oszuidwest/.github-templates
-#
-# Mirrors the audiologger CI standard: race-detected tests with shuffle, vet,
-# fmt drift check, pinned golangci-lint, deadcode, govulncheck, staticcheck.
-#
-# Optional `enable-frontend` flag adds a Bun lint job for repos that ship a
-# frontend alongside the Go service.
-
 name: Go CI
 
 on:

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -1,27 +1,6 @@
 ---
-# Reusable Go release workflow
-# Source: oszuidwest/.github-templates
-#
-# Trust-main release model: this workflow builds binaries from the tagged
-# commit and ships them. Verification (tests, lint, fmt) is the job of PR CI
-# on the way into main, not the release path. To gate a release on a custom
-# check (integration tests, smoke tests, etc.), compose via `needs:` from the
-# caller — see the README for the pattern.
-#
-# - Tag push or workflow_call with `version: edge` or `vX.Y.Z` (or `X.Y.Z`).
-# - Tag re-run guard so workflow_dispatch can be re-run on existing tags.
-#   When a tag already exists, that tag is checked out so the build matches
-#   the tag.
-# - Build matrix from JSON input.
-# - Ldflags inject PascalCase Version/Commit/BuildTime.
-# - GitHub Release with prerelease auto-detect via contains(version, '-').
-# - Edge artifact: <project>-edge-<sha>, no Docker push for edge.
-#
-# v2 dropped the nested docker job. To publish a Docker image alongside a
-# release, the caller adds a second job that calls docker-publish.yml@v1
-# directly, gated on `needs.release.outputs.is_release == 'true'`. See the
-# README for the composition pattern.
-
+# Trust-main release: builds the tagged commit and ships it. Gate on extra
+# checks (integration tests, etc.) by composing via `needs:` from the caller.
 name: Go Release
 
 on:
@@ -114,7 +93,7 @@ jobs:
               echo "version=edge-${SHORT_SHA}" >> "$GITHUB_OUTPUT"
               echo "is_release=false" >> "$GITHUB_OUTPUT"
             else
-              # Auto-prefix v if user typed "1.2.3" instead of "v1.2.3"
+              # Auto-prefix v for "1.2.3" → "v1.2.3".
               case "$INPUT_VERSION" in
                 v*) VERSION="$INPUT_VERSION" ;;
                 *)  VERSION="v$INPUT_VERSION" ;;
@@ -145,9 +124,7 @@ jobs:
             git tag "$VERSION"
             git push origin "refs/tags/$VERSION"
           fi
-          # Always end on the tag commit so the embedded COMMIT ldflag matches
-          # the tag, and any downstream docker-publish job builds from the same
-          # source as the version label.
+          # End on the tag commit so COMMIT ldflag and downstream Docker build match.
           git checkout "refs/tags/$VERSION"
 
       - name: Build binaries
@@ -159,10 +136,7 @@ jobs:
           MAIN_PACKAGE: ${{ inputs.main-package }}
         run: |
           mkdir -p dist
-          # Resolve COMMIT from HEAD, not github.sha. After a manual re-run on
-          # an existing tag the previous step checks out the tag commit; the
-          # workflow-level github.sha still points at the dispatch-commit and
-          # would yield a binary whose embedded commit doesn't match the tag.
+          # HEAD, not github.sha: previous step may have checked out the tag.
           COMMIT=$(git rev-parse HEAD)
           BUILD_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
@@ -195,8 +169,6 @@ jobs:
         with:
           tag_name: ${{ steps.version.outputs.version }}
           files: dist/*
-          # When body is non-empty, softprops/action-gh-release prepends it to
-          # the auto-generated notes. Empty body falls through to auto-only.
           body: ${{ inputs.release-body }}
           generate_release_notes: true
           draft: false

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Shared GitHub Actions for repositories at oszuidwest. Two delivery models:
 
 - **Copy-paste templates** (`workflow-templates/`, `config-templates/`) — drop-in files. Use for project-shaped pieces (Dockerfile linting, Trivy scan, shellcheck) where the consumer barely customizes.
-- **Reusable workflows** (`.github/workflows/`) — called via `uses: oszuidwest/.github-templates/.github/workflows/<name>.yml@vX` (per-workflow major: `go-ci.yml@v1`, `go-release.yml@v2`, `docker-publish.yml@v1`). Use for the larger Go CI/release/Docker pipeline where parameterization replaces copy-paste drift.
+- **Reusable workflows** (`.github/workflows/`) — called via `uses: oszuidwest/.github-templates/.github/workflows/<name>.yml@v2`. Use for the larger Go CI/release/Docker pipeline where parameterization replaces copy-paste drift.
 
 ## Copy-paste templates
 
@@ -36,7 +36,7 @@ env:
 
 ## Reusable workflows
 
-Call from the consumer repo's own `.github/workflows/` files. Pinning to the moving major tag (`@v1`, `@v2`) follows template fixes automatically; pinning to a patch tag (`@v1.0.0`, `@v2.0.0`) freezes. Each reusable workflow has its own major line — see the per-workflow examples below for current versions.
+Call from the consumer repo's own `.github/workflows/` files. Pinning to the moving major tag (`@v2`) follows template fixes automatically; pinning to a patch tag (`@v2.0.0`) freezes.
 
 ### `go-ci.yml` — Go CI
 
@@ -48,7 +48,7 @@ on:
 permissions: { contents: read }
 jobs:
   ci:
-    uses: oszuidwest/.github-templates/.github/workflows/go-ci.yml@v1
+    uses: oszuidwest/.github-templates/.github/workflows/go-ci.yml@v2
     with:
       golangci-lint-version: v2.12.1
 ```
@@ -60,7 +60,7 @@ Inputs:
 | `golangci-lint-version` | string | no | `v2.12.1` | Passed to `golangci/golangci-lint-action`. |
 | `go-version-file` | string | no | `go.mod` | Passed to `actions/setup-go`. |
 | `enable-frontend` | boolean | no | `false` | Adds the frontend lint job. |
-| `frontend-tool` | string | no | `bun` | Only `bun` is supported in v1. |
+| `frontend-tool` | string | no | `bun` | Only `bun` is supported. |
 
 The Go job runs `go test -race -shuffle=on -v ./...`, `go vet`, `go fmt` with diff check, golangci-lint, `deadcode`, `govulncheck`, and `staticcheck`. Consumers must keep `deadcode`, `govulncheck`, and `staticcheck` available through Go tool directives in `go.mod`.
 
@@ -126,7 +126,7 @@ jobs:
   docker:
     needs: release
     if: needs.release.outputs.is_release == 'true'
-    uses: oszuidwest/.github-templates/.github/workflows/docker-publish.yml@v1
+    uses: oszuidwest/.github-templates/.github/workflows/docker-publish.yml@v2
     with:
       version: ${{ needs.release.outputs.version }}
       image-labels: |
@@ -150,7 +150,7 @@ on:
 permissions: { contents: read }
 jobs:
   publish:
-    uses: oszuidwest/.github-templates/.github/workflows/docker-publish.yml@v1
+    uses: oszuidwest/.github-templates/.github/workflows/docker-publish.yml@v2
     with:
       version: ${{ github.ref_name }}
     permissions:
@@ -204,10 +204,10 @@ The custom job lives in the consumer repo, the template stays small, and `needs:
 ## Maintenance contract
 
 - **Versioning:** semver. Patch for compatible bug fixes and documentation clarifications, minor for additive optional inputs, major for breaking changes (renamed/removed inputs, permission model changes, or default changes that break consumers). Each major line keeps an immutable `vX.Y.Z` and a moving `vX` tag; consumers pin to `@vX` to follow fixes, `@vX.Y.Z` to freeze.
-- **Active major lines:** `v1` (legacy — `go-release.yml` with nested `docker` job) and `v2` (current — composes with `docker-publish.yml` from a separate caller job). New consumers pin `@v2`; v1 stays available for already-pinned consumers until they migrate.
+- **Active major lines:** `v2` only. The `v1` line was retired in 2026-05 (zero remaining consumers); its tags no longer resolve.
 - **Release tags:** after a validated merge to `main`, tag the exact merge commit and move the major tag:
   ```bash
-  VERSION=v2.0.1   # or v1.x.y for a v1-line patch
+  VERSION=v2.0.1
   MAJOR=v2         # match VERSION's major
   git fetch origin main --tags
   git switch main
@@ -233,6 +233,8 @@ The custom job lives in the consumer repo, the template stays small, and `needs:
 
 ### Migrating `go-release.yml` from v1 to v2
 
+> **Note:** the `v1` tag was retired in 2026-05 — `go-release.yml@v1` no longer resolves. The steps below are kept as historical reference for anyone whose repo still carries v1 syntax. Replace `@v1` with `@v2` and follow the migration before pushing.
+
 v2 dropped the nested `docker` job and the four inputs that fed it (`enable-docker`, `image-labels`, `dockerfile-path`, `platforms`). Consumers that publish a Docker image now add a second job that calls `docker-publish.yml` directly.
 
 For a consumer currently calling `go-release.yml@v1` with `enable-docker: true`:
@@ -240,7 +242,7 @@ For a consumer currently calling `go-release.yml@v1` with `enable-docker: true`:
 1. Bump `@v1` → `@v2` on the release job.
 2. Drop `enable-docker`, `image-labels`, `dockerfile-path`, `platforms` from the release call.
 3. Drop `packages: write` from the release job's permissions (`contents: write` is enough now).
-4. Add a second job that calls `docker-publish.yml@v1` with `needs: release`, gated on `needs.release.outputs.is_release == 'true'`, and forwards `version` from the release outputs. See "Releasing with a Docker image" for the full snippet.
+4. Add a second job that calls `docker-publish.yml@v2` with `needs: release`, gated on `needs.release.outputs.is_release == 'true'`, and forwards `version` from the release outputs. See "Releasing with a Docker image" for the full snippet.
 
 For a consumer currently calling `go-release.yml@v1` with `enable-docker: false`:
 

--- a/workflow-templates/docker-quality.yml
+++ b/workflow-templates/docker-quality.yml
@@ -1,17 +1,5 @@
 ---
-# Docker Quality Workflow Template
-# Source: oszuidwest/.github-templates
-#
-# This workflow lints Dockerfiles, validates YAML, and checks Docker Compose files.
-# Copy to: .github/workflows/docker-quality.yml
-#
-# Required config files:
-#   - .hadolint.yaml (at repo root)
-#
-# Customization:
-#   - DOCKERFILE_PATH: Change if Dockerfile is not at root (e.g., "docker/Dockerfile")
-#   - Adjust YAML lint rules in the inline config as needed
-
+# Requires .hadolint.yaml at the repo root.
 name: Docker Quality
 
 on:
@@ -50,7 +38,7 @@ jobs:
             echo "has_dockerfile=false" >> "$GITHUB_OUTPUT"
           fi
 
-      # Configuration in .hadolint.yaml - do NOT duplicate ignore rules here
+      # Ignore rules live in .hadolint.yaml — do not duplicate here.
       - name: Hadolint
         if: steps.check_dockerfile.outputs.has_dockerfile == 'true'
         uses: hadolint/hadolint-action@v3.3.0
@@ -95,7 +83,7 @@ jobs:
             touch .env
           fi
           if ! OUTPUT=$(docker compose config --quiet 2>&1); then
-            # Missing env vars = warning, syntax errors = fail
+            # Missing env vars: warn. Syntax errors: fail.
             if echo "$OUTPUT" | grep -qi "variable is not set"; then
               echo "::warning::Docker Compose validation requires environment variables: $OUTPUT"
             else

--- a/workflow-templates/docker-security.yml
+++ b/workflow-templates/docker-security.yml
@@ -1,16 +1,4 @@
 ---
-# Docker Security Workflow Template
-# Source: oszuidwest/.github-templates
-#
-# This workflow scans Docker images for vulnerabilities using Trivy.
-# Results are uploaded to GitHub Security tab via SARIF.
-#
-# Copy to: .github/workflows/docker-security.yml
-#
-# Customization:
-#   - DOCKERFILE_PATH: Change if Dockerfile is not at root
-#   - Adjust severity levels as needed (CRITICAL, HIGH, MEDIUM, LOW)
-
 name: Docker Security
 
 on:
@@ -18,8 +6,7 @@ on:
     branches: [main]
   pull_request:
   schedule:
-    # Weekly on Sunday at 4 AM UTC
-    - cron: '0 4 * * 0'
+    - cron: '0 4 * * 0'  # Weekly Sunday 04:00 UTC
   workflow_dispatch:
   workflow_call:
 
@@ -66,7 +53,7 @@ jobs:
           restore-keys: |
             trivy-db
 
-      # Includes MEDIUM for visibility in Security tab
+      # MEDIUM included so they surface in the Security tab.
       - name: Trivy SARIF Report
         uses: aquasecurity/trivy-action@v0.36.0
         with:

--- a/workflow-templates/shell-quality.yml
+++ b/workflow-templates/shell-quality.yml
@@ -1,15 +1,4 @@
 ---
-# Shell Quality Workflow Template
-# Source: oszuidwest/.github-templates
-#
-# This workflow lints shell scripts using ShellCheck.
-# Only triggers when .sh files are modified (path filter).
-#
-# Copy to: .github/workflows/shell-quality.yml
-#
-# Note: This workflow is "forward-looking" - it will activate
-# automatically when .sh files are added to the repository.
-
 name: Shell Quality
 
 on:


### PR DESCRIPTION
## Summary
- Drop "Source / Copy to / Customization" header blocks from `workflow-templates/*` and `.github/workflows/*` — README is the canonical source for usage.
- Compress remaining WHY-comments to single lines.
- Keep all functional behavior unchanged.

## Test plan
- [x] `git diff --stat` confirms only comment lines changed
- [ ] CI green on PR