### PR TITLE
feat(go-ci): self-install analysis tools instead of go.mod tool directives

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -22,6 +22,18 @@ on:
           Only "bun" is supported in v1.
         type: string
         default: 'bun'
+      deadcode-version:
+        description: 'golang.org/x/tools/cmd/deadcode version'
+        type: string
+        default: 'v0.28.0'
+      govulncheck-version:
+        description: 'golang.org/x/vuln/cmd/govulncheck version'
+        type: string
+        default: 'v1.1.4'
+      staticcheck-version:
+        description: 'honnef.co/go/tools/cmd/staticcheck version'
+        type: string
+        default: '2024.1.1'
 
 permissions:
   contents: read
@@ -58,19 +70,30 @@ jobs:
           version: ${{ inputs.golangci-lint-version }}
           args: --timeout=5m
 
+      # Installed centrally so consumers don't need tool directives in go.mod.
+      - name: Install Go analysis tools
+        env:
+          DEADCODE_VERSION: ${{ inputs.deadcode-version }}
+          GOVULNCHECK_VERSION: ${{ inputs.govulncheck-version }}
+          STATICCHECK_VERSION: ${{ inputs.staticcheck-version }}
+        run: |
+          go install "golang.org/x/tools/cmd/deadcode@${DEADCODE_VERSION}"
+          go install "golang.org/x/vuln/cmd/govulncheck@${GOVULNCHECK_VERSION}"
+          go install "honnef.co/go/tools/cmd/staticcheck@${STATICCHECK_VERSION}"
+
       - name: Check for dead code
         run: |
-          deadcode_output=$(go tool deadcode ./...)
+          deadcode_output=$(deadcode ./...)
           if [ -n "$deadcode_output" ]; then
             echo "$deadcode_output"
             exit 1
           fi
 
       - name: Run govulncheck
-        run: go tool govulncheck ./...
+        run: govulncheck ./...
 
       - name: Run staticcheck
-        run: go tool staticcheck ./...
+        run: staticcheck ./...
 
   frontend:
     name: Frontend


### PR DESCRIPTION
## Summary
- Replaces `go tool deadcode/govulncheck/staticcheck` calls with `go install` invocations using pinned versions exposed as workflow inputs (`deadcode-version`, `govulncheck-version`, `staticcheck-version`).
- Removes the implicit dependency on consumer `go.mod` `tool` directives.

## Why
None of the Go consumer repos (babbel, metadata, aeronapi, aerontoolbox, encoder) currently declare these tools via Go 1.24 `tool` directives in `go.mod`. With the previous `go tool X` invocations, migrating any consumer to `go-ci@v2` would fail until that repo added matching `tool` directives - exactly the per-repo drift centralization is meant to avoid. Centrally pinned `go install` versions let consumers migrate without touching their `go.mod`.

Defaults pinned to: deadcode `v0.28.0`, govulncheck `v1.1.4`, staticcheck `2024.1.1`. Bump in this workflow when desired - all consumers pick it up automatically via the `@v2` ref.

## Test plan
- [ ] Run this workflow against a Go consumer (e.g. `zwfm-aerontoolbox`) to verify deadcode/govulncheck/staticcheck still execute and report identical findings.
- [ ] Confirm Go module cache hits after first run (no per-run rebuild penalty).