### PR TITLE
feat: WordPress plugin test and release reusable workflows

### DIFF
--- a/.github/workflows/wp-ci.yml
+++ b/.github/workflows/wp-ci.yml
@@ -1,0 +1,104 @@
+---
+# Strict shape: zero inputs. PHP matrix, plugin-check, and i18n behavior are
+# fixed; the i18n job auto-detects via languages/*.pot.
+name: WP CI
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  php:
+    name: PHP ${{ matrix.php }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ["8.3", "8.4"]
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: curl
+          coverage: none
+          tools: composer:v2, cs2pr
+
+      - name: Validate PHP syntax
+        run: find . -maxdepth 1 -name '*.php' -exec php --syntax-check {} +
+
+      - name: Validate composer.json
+        run: composer validate --no-check-publish
+
+      - name: Install dependencies
+        run: composer install --no-progress --prefer-dist --optimize-autoloader
+
+      - name: PHP_CodeSniffer
+        run: vendor/bin/phpcs -q --report=checkstyle | cs2pr
+
+      - name: PHPStan
+        run: vendor/bin/phpstan analyse --error-format=checkstyle | cs2pr
+
+      - name: WordPress plugin check
+        if: matrix.php == '8.4'
+        uses: wordpress/plugin-check-action@v1
+        with:
+          exclude-checks: |
+            late_escaping
+            plugin_review_phpcs
+            file_type
+            plugin_readme
+
+  translations:
+    name: Translations
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Detect POT file
+        id: detect
+        run: |
+          POT_FILE=$(find languages -maxdepth 1 -name '*.pot' -type f \
+            2>/dev/null | head -1)
+          if [ -n "$POT_FILE" ]; then
+            SLUG=$(basename "$POT_FILE" .pot)
+            {
+              echo "has_pot=true"
+              echo "pot_file=$POT_FILE"
+              echo "slug=$SLUG"
+            } >> "$GITHUB_OUTPUT"
+          else
+            echo "has_pot=false" >> "$GITHUB_OUTPUT"
+            echo "No POT file found in languages/; skipping translation check."
+          fi
+
+      - uses: shivammathur/setup-php@v2
+        if: steps.detect.outputs.has_pot == 'true'
+        with:
+          php-version: "8.3"
+          coverage: none
+          tools: wp-cli
+
+      - name: Verify POT is up-to-date
+        if: steps.detect.outputs.has_pot == 'true'
+        env:
+          POT_FILE: ${{ steps.detect.outputs.pot_file }}
+          SLUG: ${{ steps.detect.outputs.slug }}
+        run: |
+          NEW_POT="languages/${SLUG}-new.pot"
+          wp i18n make-pot . "$NEW_POT" \
+            --slug="$SLUG" --domain="$SLUG" --skip-audit
+          comm -13 \
+            <(grep "^msgid " "$POT_FILE" | sort) \
+            <(grep "^msgid " "$NEW_POT" | sort) > /tmp/missing.txt
+          if [ -s /tmp/missing.txt ]; then
+            echo "::error::Missing translation strings in $POT_FILE:"
+            cat /tmp/missing.txt
+            echo ""
+            echo "Run: wp i18n make-pot . $POT_FILE --slug=$SLUG --domain=$SLUG"
+            exit 1
+          fi
+          echo "All translation strings are present in $POT_FILE."

--- a/.github/workflows/wp-js-ci.yml
+++ b/.github/workflows/wp-js-ci.yml
@@ -1,0 +1,28 @@
+---
+# Strict shape: zero inputs. Node 24, npm ci, npm run lint.
+# Convention: consumer's package.json defines the lint script (typically biome).
+name: WP JS CI
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Biome
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint

--- a/.github/workflows/wp-release.yml
+++ b/.github/workflows/wp-release.yml
@@ -1,0 +1,196 @@
+---
+# Manual + version-bump release. Reads VERSION from <plugin-slug>.php header,
+# compares against latest git tag, tags + zips + publishes when bumped (or
+# forced). Translations are auto-compiled when languages/*.po exists.
+name: WP Release
+
+on:
+  workflow_call:
+    inputs:
+      plugin-slug:
+        description: >-
+          Plugin slug. Used as zip rootdir, zip filename, and expected main
+          PHP file name (<slug>.php in repo root). Defaults to the calling
+          repository name.
+        type: string
+        default: ''
+      force:
+        description: 'Release even if the version was not bumped.'
+        type: boolean
+        default: false
+    outputs:
+      version:
+        description: 'Version extracted from the plugin header.'
+        value: ${{ jobs.release.outputs.version }}
+      released:
+        description: '`true` when a GitHub release was created.'
+        value: ${{ jobs.release.outputs.released }}
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      version: ${{ steps.decide.outputs.version }}
+      released: ${{ steps.decide.outputs.release_needed }}
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Resolve plugin slug and main file
+        id: slug
+        env:
+          INPUT_SLUG: ${{ inputs.plugin-slug }}
+          REPO_NAME: ${{ github.event.repository.name }}
+        run: |
+          SLUG="${INPUT_SLUG:-$REPO_NAME}"
+          MAIN_FILE="${SLUG}.php"
+          if [ ! -f "$MAIN_FILE" ]; then
+            echo "::error::Main plugin file '$MAIN_FILE' missing at repo root."
+            echo "::error::Set 'plugin-slug' if it differs from the repo name."
+            exit 1
+          fi
+          echo "slug=$SLUG" >> "$GITHUB_OUTPUT"
+          echo "main_file=$MAIN_FILE" >> "$GITHUB_OUTPUT"
+
+      - name: Extract and validate version
+        id: version
+        env:
+          MAIN_FILE: ${{ steps.slug.outputs.main_file }}
+        run: |
+          VERSION=$(sed -n \
+            's/.*Version:[[:space:]]*\([0-9a-zA-Z.-]\+\).*/\1/p' \
+            "$MAIN_FILE" | head -1)
+          PRE='(-(alpha|beta|rc)\.[0-9]+)?'
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+${PRE}$ ]]; then
+            echo "::error::Invalid version in $MAIN_FILE: '$VERSION'."
+            echo "::error::Expected X.Y.Z or X.Y.Z-(alpha|beta|rc).N"
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Decide whether to release
+        id: decide
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          FORCE: ${{ inputs.force }}
+        run: |
+          LATEST_TAG=$(git describe --tags \
+            "$(git rev-list --tags --max-count=1)" 2>/dev/null || echo "")
+          version_gt() {
+            test "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$1"
+          }
+          if [ "$FORCE" = "true" ]; then
+            DECISION=true
+            REASON="forced"
+          elif [ -z "$LATEST_TAG" ]; then
+            DECISION=true
+            REASON="first release"
+          elif version_gt "$VERSION" "$LATEST_TAG"; then
+            DECISION=true
+            REASON="version bumped from $LATEST_TAG to $VERSION"
+          else
+            DECISION=false
+            REASON="no bump (latest: $LATEST_TAG, header: $VERSION)"
+          fi
+          echo "Release decision: $DECISION ($REASON)"
+          echo "release_needed=$DECISION" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Tag the new version
+        if: steps.decide.outputs.release_needed == 'true'
+        env:
+          VERSION: ${{ steps.decide.outputs.version }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          if git rev-parse -q --verify "refs/tags/$VERSION" >/dev/null; then
+            echo "Tag $VERSION already exists; reusing it (force path)."
+          else
+            git tag "$VERSION"
+            git push origin "refs/tags/$VERSION"
+          fi
+
+      - name: Setup PHP
+        if: steps.decide.outputs.release_needed == 'true'
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.3"
+          coverage: none
+          tools: composer:v2
+
+      - name: Install production dependencies
+        if: steps.decide.outputs.release_needed == 'true'
+        run: composer install --no-dev --optimize-autoloader
+
+      - name: Compile translations
+        if: steps.decide.outputs.release_needed == 'true'
+        run: |
+          if compgen -G "languages/*.po" > /dev/null; then
+            sudo apt-get update
+            sudo apt-get install -y gettext
+            for po in languages/*.po; do
+              msgfmt -o "${po%.po}.mo" "$po"
+              echo "Compiled $po"
+            done
+          else
+            echo "No .po files found in languages/; skipping msgfmt."
+          fi
+
+      - name: Build release zip
+        if: steps.decide.outputs.release_needed == 'true'
+        id: package
+        env:
+          SLUG: ${{ steps.slug.outputs.slug }}
+          VERSION: ${{ steps.decide.outputs.version }}
+        run: |
+          mkdir -p "release/$SLUG"
+          rsync -a ./ "release/$SLUG/" \
+            --exclude='/release/' \
+            --exclude='/.git/' \
+            --exclude='/.github/' \
+            --exclude='/.claude/' \
+            --exclude='/node_modules/' \
+            --exclude='composer.json' \
+            --exclude='composer.lock' \
+            --exclude='package.json' \
+            --exclude='package-lock.json' \
+            --exclude='biome.json' \
+            --exclude='phpcs.xml' \
+            --exclude='phpcs.xml.dist' \
+            --exclude='phpstan.neon' \
+            --exclude='phpstan-bootstrap.php' \
+            --exclude='*.log' \
+            --exclude='.gitignore' \
+            --exclude='CLAUDE.md' \
+            --exclude='AGENTS.md' \
+            --exclude='.DS_Store'
+          ZIP="${SLUG}-${VERSION}.zip"
+          (cd release && zip -r "../$ZIP" "$SLUG")
+          ls -la "$ZIP"
+          echo "zip=$ZIP" >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub release
+        if: steps.decide.outputs.release_needed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.decide.outputs.version }}
+          ZIP: ${{ steps.package.outputs.zip }}
+        run: |
+          ARGS=("$VERSION" "$ZIP" --title "$VERSION" --generate-notes)
+          if [[ "$VERSION" == *-* ]]; then
+            ARGS+=(--prerelease)
+          fi
+          gh release create "${ARGS[@]}"
+
+      - name: Report skipped release
+        if: steps.decide.outputs.release_needed != 'true'
+        run: |
+          echo "::notice::Skipping release: no version bump."
+          echo "Re-run the workflow with the 'force' input to release anyway."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,42 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+
+- `README.md` documents the public contract, usage examples, inputs, outputs, and release process.
+- `.github/workflows/` contains reusable workflows called with `uses: oszuidwest/.github-templates/.github/workflows/<name>.yml@v2`. Go/Docker reusables (`go-ci.yml`, `go-release.yml`, `docker-publish.yml`) and WordPress reusables (`wp-ci.yml`, `wp-js-ci.yml`, `wp-release.yml`) live side by side.
+- `workflow-templates/` contains copy-paste workflow files for consumer repositories.
+- `config-templates/` contains supporting config files such as Dependabot and Hadolint templates.
+
+There is no application source tree or test suite. Workflow YAML and documentation examples are the primary deliverables.
+
+## Build, Test, and Development Commands
+
+No build step is required. Validate changes before opening a PR:
+
+- `git diff --check` checks for whitespace errors.
+- `yamllint .github/workflows workflow-templates config-templates` validates YAML style if `yamllint` is installed.
+- `actionlint .github/workflows/*.yml workflow-templates/*.yml` validates GitHub Actions syntax if `actionlint` is installed.
+
+For behavior changes, copy the edited workflow into a representative consumer repository or call it from a test branch before release.
+
+## Coding Style & Naming Conventions
+
+Use two-space indentation for YAML. Start YAML files with `---`. Keep workflow and job names clear and stable. Prefer kebab-case filenames, for example `go-release.yml` or `docker-security.yml`.
+
+Keep permissions minimal and explicit. Default to `permissions: { contents: read }` unless a step requires more. Pin third-party actions to explicit versions, and preserve existing input names unless making a documented major release.
+
+## Testing Guidelines
+
+Testing is validation-focused. Run YAML and Actions linting for every workflow change. For reusable workflows, verify `workflow_call` inputs, outputs, permissions, and failure behavior against `README.md`.
+
+When changing copy-paste templates, confirm they still work when copied into a consumer repository without repository-specific assumptions beyond those documented in the file.
+
+## Commit & Pull Request Guidelines
+
+Use Conventional Commits as shown in the history: `feat(release): ...`, `fix: ...`, `docs: ...`, or `chore: ...`. Mark breaking changes with `!`, for example `feat(release)!: ...`.
+
+Pull requests should describe affected templates or reusable workflows, explain consumer impact, and link related issues. Include validation evidence such as linter output, a dry run, or a consumer smoke test. Update `README.md` whenever inputs, outputs, permissions, examples, or release behavior change.
+
+## Release & Compatibility Notes
+
+Follow semver. Patch releases are for compatible fixes and docs clarifications, minor releases add optional behavior, and major releases cover breaking workflow contracts. After merging to `main`, tag the exact merge commit and move the matching major tag, as documented in `README.md`.

--- a/README.md
+++ b/README.md
@@ -168,6 +168,93 @@ Inputs:
 | `platforms` | string | no | `linux/amd64,linux/arm64` | Comma-separated Docker buildx platforms. |
 | `image-labels` | string | no | `''` | Multiline OCI labels passed to metadata/build. |
 
+### `wp-ci.yml` - WordPress plugin lint
+
+Strict shape, no inputs. PHP matrix `["8.3", "8.4"]`, fixed `wp-plugin-check` excludes, optional translations job that auto-runs when `languages/*.pot` exists.
+
+```yaml
+name: Lint
+on:
+  push: { branches: [main], paths: ['**/*.php', 'composer.json', 'composer.lock', 'phpcs.xml', 'phpstan.neon', 'languages/**'] }
+  pull_request: { paths: ['**/*.php', 'composer.json', 'composer.lock', 'phpcs.xml', 'phpstan.neon', 'languages/**'] }
+  workflow_dispatch:
+permissions: { contents: read }
+jobs:
+  lint:
+    uses: oszuidwest/.github-templates/.github/workflows/wp-ci.yml@v2
+```
+
+The `php` job runs `php --syntax-check`, `composer validate`, `composer install`, `phpcs` (checkstyle/cs2pr), `phpstan` (checkstyle/cs2pr), and `wordpress/plugin-check-action@v1` once on PHP 8.4. Plugin-check excludes are fixed to `late_escaping`, `plugin_review_phpcs`, `file_type`, `plugin_readme`. Plugins that fail other checks fix it in code rather than configuring the workflow.
+
+The `translations` job auto-detects `languages/*.pot`, runs `wp i18n make-pot` against a fresh copy, and fails on missing strings. Slug and domain are derived from the POT filename (e.g. `languages/foo.pot` -> slug+domain `foo`).
+
+Consumer requirements: `composer.json` declares `phpcs` and `phpstan` as dev dependencies; `phpcs.xml` (or `phpcs.xml.dist`) and `phpstan.neon` exist at repo root.
+
+### `wp-js-ci.yml` - WordPress plugin JS lint
+
+Strict shape, no inputs. Node 24, `npm ci`, `npm run lint`. Convention: consumer's `package.json` defines `lint` (typically `biome check assets/`).
+
+```yaml
+name: JS Lint
+on:
+  push: { branches: [main], paths: ['**/*.js', '**/*.ts', '**/*.css', 'package.json', 'package-lock.json', 'biome.json'] }
+  pull_request: { paths: ['**/*.js', '**/*.ts', '**/*.css', 'package.json', 'package-lock.json', 'biome.json'] }
+  workflow_dispatch:
+permissions: { contents: read }
+jobs:
+  lint:
+    uses: oszuidwest/.github-templates/.github/workflows/wp-js-ci.yml@v2
+```
+
+### `wp-release.yml` - WordPress plugin release
+
+Manual `workflow_dispatch`. Reads the `Version:` header from `<plugin-slug>.php`, compares against the latest git tag, and tags + zips + publishes when bumped (or when `force: true`). Translations are auto-compiled when `languages/*.po` exists.
+
+```yaml
+name: Release
+on:
+  workflow_dispatch:
+    inputs:
+      force:
+        description: 'Release even if the version was not bumped'
+        type: boolean
+        default: false
+permissions: { contents: read }
+jobs:
+  release:
+    uses: oszuidwest/.github-templates/.github/workflows/wp-release.yml@v2
+    with:
+      force: ${{ inputs.force }}
+      # plugin-slug: zuidwest-cache-manager  # override only if slug != repo name
+    permissions:
+      contents: write
+```
+
+Inputs:
+
+| Input | Type | Required | Default | Notes |
+|-------|------|----------|---------|-------|
+| `plugin-slug` | string | no | repo name | Used as zip rootdir, zip filename, and expected main file (`<slug>.php` at repo root). Override only when slug differs from repo name. |
+| `force` | boolean | no | `false` | Release even when the version is not bumped. |
+
+Outputs:
+
+| Output | Notes |
+|--------|-------|
+| `version` | Version extracted from the plugin header. |
+| `released` | `'true'` when a GitHub release was created, `'false'` when skipped. |
+
+**Fixed shape (no inputs):**
+
+- Version regex: `^[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+)?$`. Pre-release versions (`X.Y.Z-beta.N`, etc.) are auto-marked `prerelease` on the GitHub release.
+- Production build: PHP 8.3 + `composer install --no-dev --optimize-autoloader`.
+- Translations: `msgfmt` runs over `languages/*.po` when any exist. `vendor/` and the compiled `.mo` files are bundled into the zip.
+- rsync exclude list (kept identical across consumers): `release/`, `.git/`, `.github/`, `.claude/`, `node_modules/`, `composer.json`, `composer.lock`, `package.json`, `package-lock.json`, `biome.json`, `phpcs.xml`, `phpcs.xml.dist`, `phpstan.neon`, `phpstan-bootstrap.php`, `*.log`, `.gitignore`, `CLAUDE.md`, `AGENTS.md`, `.DS_Store`. `vendor/` and `README.md` are kept in the zip.
+
+The release job tags the current commit, builds `<slug>-<version>.zip`, and creates a GitHub release with `--generate-notes`. If the latest tag already matches the header version and `force` is `false`, the workflow exits with a notice and the `released` output is `'false'`.
+
+The `plugin-slug` input exists for plugins where the slug currently differs from the repo name (`zw-cacheman` -> `zuidwest-cache-manager`, `zw-liveblog` -> `zuidwest-liveblog`, `zw-gr26-wp` -> `zw-gr26`). Those plugins have open rename issues; once landed, they can drop the override.
+
 ### Composing custom pre-release gates
 
 `go-release.yml` is build-and-ship only - it does not run tests, lint, or fmt. The assumption is that PR CI already gated the merge into main, so a tag on main is releasable by construction. This is the standard "trust main" model: don't repeat verification work in the release path.

--- a/workflow-templates/wp-js-lint.yml
+++ b/workflow-templates/wp-js-lint.yml
@@ -1,0 +1,29 @@
+---
+name: JS Lint
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '**/*.js'
+      - '**/*.ts'
+      - '**/*.css'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'biome.json'
+  pull_request:
+    paths:
+      - '**/*.js'
+      - '**/*.ts'
+      - '**/*.css'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'biome.json'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    uses: oszuidwest/.github-templates/.github/workflows/wp-js-ci.yml@v2

--- a/workflow-templates/wp-lint.yml
+++ b/workflow-templates/wp-lint.yml
@@ -1,0 +1,33 @@
+---
+name: Lint
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '**/*.php'
+      - 'composer.json'
+      - 'composer.lock'
+      - 'phpcs.xml'
+      - 'phpcs.xml.dist'
+      - 'phpstan.neon'
+      - 'phpstan-bootstrap.php'
+      - 'languages/**'
+  pull_request:
+    paths:
+      - '**/*.php'
+      - 'composer.json'
+      - 'composer.lock'
+      - 'phpcs.xml'
+      - 'phpcs.xml.dist'
+      - 'phpstan.neon'
+      - 'phpstan-bootstrap.php'
+      - 'languages/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    uses: oszuidwest/.github-templates/.github/workflows/wp-ci.yml@v2

--- a/workflow-templates/wp-release.yml
+++ b/workflow-templates/wp-release.yml
@@ -1,0 +1,25 @@
+---
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      force:
+        description: 'Release even if the version was not bumped'
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    uses: oszuidwest/.github-templates/.github/workflows/wp-release.yml@v2
+    with:
+      force: ${{ inputs.force }}
+      # Override only when the plugin slug differs from the repository name
+      # (e.g. zw-cacheman -> zuidwest-cache-manager). The slug must match the
+      # main PHP file: <slug>.php at the repo root.
+      # plugin-slug: zuidwest-cache-manager
+    permissions:
+      contents: write


### PR DESCRIPTION
## Summary

- Three new reusables (`wp-ci.yml`, `wp-js-ci.yml`, `wp-release.yml`) plus matching copy-paste templates so the nine oszuidwest WordPress plugins can drop ~150 lines of drifting per-repo workflow YAML in favour of ~10-line callers.
- Strict shape on purpose: zero inputs on the two lint reusables; only `plugin-slug` (default repo name) and `force` on release. Translations and `.po` compilation auto-detect off the filesystem (`languages/*.pot`, `languages/*.po`); there are no `enable-*` booleans.
- Plugin-check excludes, PHP matrix, rsync exclude list and version regex are hardcoded. Plugins that currently need workarounds (slug != repo name, two-segment version headers, extra plugin-check excludes) get tracked as follow-up issues rather than accommodated by template inputs.

## Migration follow-ups (separate issues)

- `zw-cacheman` (oszuidwest/zw-cacheman#37), `zw-gr26-wp` (oszuidwest/zw-gr26-wp#27): rename main file/slug to match repo name so the `plugin-slug` override can disappear.
- `zw-liveblog`: rename slug + bump version `1.7` -> `1.7.0` (issues disabled on that repo; tracked here).
- `aandacht` (oszuidwest/aandacht#1): fix `direct_db` and `prefixing` plugin-check violations in code; bump version `2.11` -> `2.11.0`; upgrade to `actions/checkout@v6`.
- `zw-ttvgpt` (oszuidwest/zw-ttvgpt#146): relocate or rename `phpstan-bootstrap.php` so the `exclude-files` override can disappear.

## Test plan

- [ ] Pin `zw-cacheman` (`lint.yml` + `release.yml`) to this branch via `@<merge-sha>` and run lint on a test PR (must pass on PHP 8.3 and 8.4).
- [ ] On `zw-cacheman`: run `release` workflow_dispatch with `force: false` against an unchanged version (must skip with notice).
- [ ] On `zw-cacheman`: bump version, run `release` workflow_dispatch (must tag, build zip, create GitHub release with `--generate-notes`).
- [ ] On `zw-knabbel-wp`: pin to this branch; verify `translations` job auto-runs (POT exists) and that `.mo` files end up inside the released zip.
- [ ] After both smoke tests pass: tag `v2.1.0` on the merge commit and move the `v2` tag.
- [ ] After `v2` moves: monitor first run on each migrated plugin consumer.