### PR TITLE
fix(wp-release): exclude phpstan-bootstrap.stub from release zip

### DIFF
--- a/.github/workflows/wp-release.yml
+++ b/.github/workflows/wp-release.yml
@@ -166,6 +166,7 @@ jobs:
             --exclude='phpcs.xml.dist' \
             --exclude='phpstan.neon' \
             --exclude='phpstan-bootstrap.php' \
+            --exclude='phpstan-bootstrap.stub' \
             --exclude='*.log' \
             --exclude='.gitignore' \
             --exclude='CLAUDE.md' \

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ Outputs:
 - Version regex: `^[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+)?$`. Pre-release versions (`X.Y.Z-beta.N`, etc.) are auto-marked `prerelease` on the GitHub release.
 - Production build: PHP 8.3 + `composer install --no-dev --optimize-autoloader`.
 - Translations: `msgfmt` runs over `languages/*.po` when any exist. `vendor/` and the compiled `.mo` files are bundled into the zip.
-- rsync exclude list (kept identical across consumers): `release/`, `.git/`, `.github/`, `.claude/`, `node_modules/`, `composer.json`, `composer.lock`, `package.json`, `package-lock.json`, `biome.json`, `phpcs.xml`, `phpcs.xml.dist`, `phpstan.neon`, `phpstan-bootstrap.php`, `*.log`, `.gitignore`, `CLAUDE.md`, `AGENTS.md`, `.DS_Store`. `vendor/` and `README.md` are kept in the zip.
+- rsync exclude list (kept identical across consumers): `release/`, `.git/`, `.github/`, `.claude/`, `node_modules/`, `composer.json`, `composer.lock`, `package.json`, `package-lock.json`, `biome.json`, `phpcs.xml`, `phpcs.xml.dist`, `phpstan.neon`, `phpstan-bootstrap.php`, `phpstan-bootstrap.stub`, `*.log`, `.gitignore`, `CLAUDE.md`, `AGENTS.md`, `.DS_Store`. `vendor/` and `README.md` are kept in the zip.
 
 The release job tags the current commit, builds `<slug>-<version>.zip`, and creates a GitHub release with `--generate-notes`. If the latest tag already matches the header version and `force` is `false`, the workflow exits with a notice and the `released` output is `'false'`.
 


### PR DESCRIPTION
Tiny patch surfaced while migrating zw-ttvgpt and zw-cacheman to the strict templates.

## Why

`phpstan-bootstrap.php` lives at the plugin root and is required by PHPStan as a runtime bootstrap (it runs `define()` calls so PHPStan knows about plugin-specific constants). WordPress plugin-check flags any `*.php` file lacking the canonical `defined( 'ABSPATH' ) || exit;` direct-access guard — but adding that guard would terminate PHPStan's bootstrap (PHPStan runs the file outside WordPress, so ABSPATH is not defined at runtime).

The strict template doesn't allow per-plugin `exclude-files` overrides on `wp-plugin-check-action`. The conventional workaround is to use a `.stub` extension: PHPStan still loads it via `bootstrapFiles`, while plugin-check (which scans only `*.php`) skips it. `tests/phpstan-bootstrap.php` was tried first but plugin-check does not exclude `tests/` by default — confirmed in oszuidwest/zw-ttvgpt#147 and oszuidwest/zw-cacheman#39.

## Change

Add `phpstan-bootstrap.stub` to the rsync exclude list in `wp-release.yml` so plugins that adopt the `.stub` convention don't ship the bootstrap inside their release zip. The existing `.php` exclusion stays for backward compatibility.

## Versioning

Patch on top of v2.2.0 (additive: more files excluded; never less). Will tag `v2.2.1` and move `v2` after merge.