### PR TITLE
fix(wp-release): strip leading v from latest tag before version compare

### DIFF
--- a/.github/workflows/wp-release.yml
+++ b/.github/workflows/wp-release.yml
@@ -83,6 +83,11 @@ jobs:
         run: |
           LATEST_TAG=$(git describe --tags \
             "$(git rev-list --tags --max-count=1)" 2>/dev/null || echo "")
+          # Compare bare versions: strip an optional leading 'v' from the tag
+          # so a header value of "0.5.2" outranks an existing "v0.5.1" tag.
+          # sort -V otherwise places the bare form before the v-prefixed one,
+          # which made version_gt return false when the prefixes differed.
+          LATEST_BARE="${LATEST_TAG#v}"
           version_gt() {
             test "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$1"
           }
@@ -92,7 +97,7 @@ jobs:
           elif [ -z "$LATEST_TAG" ]; then
             DECISION=true
             REASON="first release"
-          elif version_gt "$VERSION" "$LATEST_TAG"; then
+          elif version_gt "$VERSION" "$LATEST_BARE"; then
             DECISION=true
             REASON="version bumped from $LATEST_TAG to $VERSION"
           else


### PR DESCRIPTION
Bug spotted by review of the v2.2.x rollout.

## Symptom

zw-gr26-wp's release dispatch on 2026-05-10 succeeded as a workflow run but emitted:

```
Release decision: false (no bump (latest: v0.5.1, header: 0.5.2))
```

The header version `0.5.2` should be a bump over the existing `v0.5.1` tag but the workflow skipped. zw-ttvgpt would hit the same trap on its next bump (latest tag `v0.2.1`, header bumped to `0.2.2` would skip incorrectly).

## Root cause

`sort -V` treats `0.5.2` and `v0.5.1` as having an empty leading text-segment versus a `v` text-segment. The empty segment compares less than `v`, so:

```
$ printf '%s\n' '0.5.2' 'v0.5.1' | sort -V | head -n 1
0.5.2
```

`version_gt "0.5.2" "v0.5.1"` therefore checks whether `0.5.2` differs from itself → false → 'no bump'.

## Fix

Strip an optional leading `v` from `LATEST_TAG` before passing to the sort comparison. `VERSION` already comes from the plugin header where the strict regex disallows a leading `v`, so it needs no normalisation.

| header | latest_tag | before fix | after fix |
|---|---|---|---|
| 0.5.2 | v0.5.1 | skip ❌ | release ✅ |
| 0.2.2 | v0.2.1 | skip ❌ | release ✅ |
| 1.7.1 | 1.7 | release ✅ | release ✅ |
| 0.5.2 | v0.5.2 | skip ✅ | skip ✅ |
| 0.5.10 | v0.5.2 | release ✅ | release ✅ |

## Versioning

Patch on top of v2.2.1. Will tag `v2.2.2` and move `v2` after merge. After the tag moves, re-dispatching zw-gr26-wp's Release workflow should publish the missing 0.5.2 release.