### PR TITLE
feat: add WordPress plugin phpcs.xml.dist baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ cp workflow-templates/shell-quality.yml    .github/workflows/
 # Config
 cp config-templates/.hadolint.yaml         ./
 cp config-templates/dependabot.yml         .github/
+cp config-templates/phpcs.xml.dist         ./   # WordPress plugin baseline
 ```
 
 | Workflow | Purpose | Fails on |
@@ -33,6 +34,28 @@ env:
 ```
 
 **Adjust Hadolint rules?** Edit `.hadolint.yaml`, not the workflow.
+
+### `phpcs.xml.dist` - WordPress plugin baseline
+
+Shared phpcs ruleset for oszuidwest WordPress plugins. Drop into the plugin root as `phpcs.xml` (or `phpcs.xml.dist`) and prepend the per-plugin specifics. Required additions:
+
+```xml
+<file>my-plugin.php</file>
+<file>includes</file>
+
+<config name="text_domain" value="my-plugin"/>
+
+<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
+    <properties>
+        <property name="prefixes" type="array">
+            <element value="my_plugin"/>
+            <element value="MY_PLUGIN"/>
+        </properties>
+    </properties>
+</rule>
+```
+
+The baseline locks down `WordPress-Extra` + `WordPress-Docs` + `PHPCompatibilityWP` against `8.3-8.4` / WP 6.8+. Override this file's `<config name="testVersion"/>` only when a plugin needs a wider PHP range.
 
 ## Reusable workflows
 

--- a/config-templates/phpcs.xml.dist
+++ b/config-templates/phpcs.xml.dist
@@ -1,0 +1,47 @@
+<?xml version="1.0"?>
+<ruleset name="oszuidwest WordPress plugin baseline">
+    <description>
+        Baseline coding standards for oszuidwest WordPress plugins.
+        Consumer phpcs.xml adds &lt;file/&gt;, &lt;config name="text_domain"/&gt;,
+        and a PrefixAllGlobals rule with the plugin's prefixes.
+    </description>
+
+    <!-- Scan only PHP files. Consumer overrides /file/ entries. -->
+    <arg name="extensions" value="php"/>
+    <arg name="colors"/>
+    <arg value="sp"/>
+
+    <!-- Stop PHP 8 from emitting deprecation warnings inside phpcs itself. -->
+    <ini name="error_reporting" value="E_ALL &amp; ~E_DEPRECATED"/>
+
+    <!-- Versions enforced across all oszuidwest plugins. -->
+    <config name="testVersion" value="8.3-8.4"/>
+    <config name="minimum_wp_version" value="6.8"/>
+
+    <!--
+        WordPress-Extra is WordPress-Core plus best-practice sniffs.
+        WordPress-Docs adds docblock requirements.
+        PHPCompatibilityWP enforces the testVersion above.
+    -->
+    <rule ref="WordPress-Extra">
+        <!-- We use short array syntax. -->
+        <exclude name="Universal.Arrays.DisallowShortArraySyntax"/>
+    </rule>
+    <rule ref="WordPress-Docs">
+        <!-- PHPStan type aliases aren't real PHP types. -->
+        <exclude name="Squiz.Commenting.FunctionComment.IncorrectTypeHint"/>
+    </rule>
+    <rule ref="PHPCompatibilityWP"/>
+
+    <!-- Generous line limit; warning only. -->
+    <rule ref="Generic.Files.LineLength">
+        <properties>
+            <property name="lineLimit" value="160"/>
+            <property name="absoluteLineLimit" value="0"/>
+        </properties>
+    </rule>
+
+    <!-- Excluded from every consumer. -->
+    <exclude-pattern>vendor/*</exclude-pattern>
+    <exclude-pattern>node_modules/*</exclude-pattern>
+</ruleset>


### PR DESCRIPTION
Adds a shared phpcs ruleset for oszuidwest WordPress plugins to `config-templates/`.

## Why

Audit across 11 WP plugins showed strong convergence on `WordPress-Extra + WordPress-Docs + PHPCompatibilityWP` (5 plugins use this exact stack; 3 use the equivalent `WordPress` parent ruleset). Two plugins (`zw-liveblog`, `teksttv-editor-hacks`) use `PSR12` instead — switching them is a real code-format change, out of scope here.

The baseline gives plugins a canonical phpcs.xml to copy from, removing per-repo drift on rules they all want anyway (PHP version, WP version, line-length, vendor exclusion, etc.).

## What's in it

- `WordPress-Extra` + `WordPress-Docs` + `PHPCompatibilityWP`
- `testVersion: 8.3-8.4`, `minimum_wp_version: 6.8`
- `vendor/`, `node_modules/` excluded
- `Generic.Files.LineLength` 160 char warn
- Short-array allowed; PHPStan type aliases tolerated in docblocks

## What's NOT in it

- `<file>` entries (per-plugin)
- `text_domain` config (per-plugin)
- `PrefixAllGlobals` rule (prefixes vary per plugin)

These three layer on top in the consumer's phpcs.xml. The README documents the addition pattern.

## Versioning

Additive on top of v2.2.2 → patch bump to v2.2.3, `v2` moves.