### PR TITLE
fix(wp-ci): make phpcs warnings advisory, only errors fail

### DIFF
--- a/.github/workflows/wp-ci.yml
+++ b/.github/workflows/wp-ci.yml
@@ -37,7 +37,9 @@ jobs:
         run: composer install --no-progress --prefer-dist --optimize-autoloader
 
       - name: PHP_CodeSniffer
-        run: vendor/bin/phpcs -q --report=checkstyle | cs2pr
+        run: |
+          vendor/bin/phpcs -q --report=checkstyle \
+            --runtime-set ignore_warnings_on_exit 1 | cs2pr
 
       - name: PHPStan
         run: vendor/bin/phpstan analyse --error-format=checkstyle | cs2pr


### PR DESCRIPTION
Surfaced while migrating zw-staart and cyclusinfo to the shared phpcs baseline.

## Symptom

phpcs reported per-line warnings (long lines on staart, error_log calls on cyclus) → exit code 1 → step fails, even though no actual coding-standard errors were present.

## Cause

phpcs exits 1 on warnings by default. The CI pipe `phpcs ... | cs2pr` runs under `bash -e` with pipefail; phpcs's exit propagates and fails the step.

## Fix

Pass `--runtime-set ignore_warnings_on_exit 1` so phpcs exits 0 when only warnings are reported. cs2pr still emits `::warning::` annotations on the PR (so warnings remain visible) — they just don't fail CI.

Errors continue to fail (cs2pr returns 1 on real errors).

## Versioning

Patch on top of v2.2.3 → `v2.2.4`, `v2` moves.