### PR TITLE
fix(wp-ci): pass --graceful-warnings to cs2pr

### DIFF
--- a/.github/workflows/wp-ci.yml
+++ b/.github/workflows/wp-ci.yml
@@ -39,7 +39,8 @@ jobs:
       - name: PHP_CodeSniffer
         run: |
           vendor/bin/phpcs -q --report=checkstyle \
-            --runtime-set ignore_warnings_on_exit 1 | cs2pr
+            --runtime-set ignore_warnings_on_exit 1 \
+            | cs2pr --graceful-warnings
 
       - name: PHPStan
         run: vendor/bin/phpstan analyse --error-format=checkstyle | cs2pr


### PR DESCRIPTION
Follow-up to v2.2.4 — `--runtime-set ignore_warnings_on_exit 1` made phpcs exit 0 on warnings, but `cs2pr` still returned 1 on any violation. The pipe `bash -e -o pipefail` propagated cs2pr's failure.

`cs2pr --graceful-warnings` returns 0 when only warnings are present. Combined with the phpcs flag, warnings annotate but don't fail.

Patch on top of v2.2.4 → v2.2.5, `v2` moves.