### PR TITLE
fix: clear setup-php composer auth

### DIFF
--- a/.github/workflows/wp-ci.yml
+++ b/.github/workflows/wp-ci.yml
@@ -27,6 +27,24 @@ jobs:
           coverage: none
           tools: composer:v2, cs2pr
 
+      - name: Clear Composer GitHub auth
+        run: |
+          php -r '
+          $file = getenv("HOME") . "/.composer/auth.json";
+          if (! is_file($file)) {
+              exit(0);
+          }
+          $auth = json_decode((string) file_get_contents($file), true);
+          if (! is_array($auth)) {
+              exit(0);
+          }
+          unset($auth["github-oauth"]["github.com"]);
+          if (isset($auth["github-oauth"]) && [] === $auth["github-oauth"]) {
+              unset($auth["github-oauth"]);
+          }
+          file_put_contents($file, json_encode($auth, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . PHP_EOL);
+          '
+
       - name: Validate PHP syntax
         run: find . -maxdepth 1 -name '*.php' -exec php --syntax-check {} +
 

--- a/.github/workflows/wp-release.yml
+++ b/.github/workflows/wp-release.yml
@@ -130,6 +130,25 @@ jobs:
           coverage: none
           tools: composer:v2
 
+      - name: Clear Composer GitHub auth
+        if: steps.decide.outputs.release_needed == 'true'
+        run: |
+          php -r '
+          $file = getenv("HOME") . "/.composer/auth.json";
+          if (! is_file($file)) {
+              exit(0);
+          }
+          $auth = json_decode((string) file_get_contents($file), true);
+          if (! is_array($auth)) {
+              exit(0);
+          }
+          unset($auth["github-oauth"]["github.com"]);
+          if (isset($auth["github-oauth"]) && [] === $auth["github-oauth"]) {
+              unset($auth["github-oauth"]);
+          }
+          file_put_contents($file, json_encode($auth, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . PHP_EOL);
+          '
+
       - name: Install production dependencies
         if: steps.decide.outputs.release_needed == 'true'
         run: composer install --no-dev --optimize-autoloader


### PR DESCRIPTION
## Summary
- remove the default setup-php GitHub OAuth entry from Composer auth before Composer commands run
- cover wp-ci and wp-release workflows
- avoid using `composer config --unset` because it parses auth.json first and can trigger the same token-validation exception

## Why
Composer 2.9.x validates `github-oauth.github.com` with a regex that rejects the new GitHub Actions `ghs_...` JWT token format when it contains base64url characters like `-`. When validation fails, Composer includes the token in the exception output, and GitHub log masking can miss wrapped fragments.

## Testing
- `ruby -rpsych -e 'ARGV.each { |f| Psych.load_file(f) }' .github/workflows/wp-ci.yml .github/workflows/wp-release.yml`
- dummy auth.json with an invalid `ghs_...` token is cleaned via the PHP snippet before `composer validate`
