### PR TITLE
chore(dependabot): add composer ecosystem as opt-in option

### DIFF
--- a/config-templates/dependabot.yml
+++ b/config-templates/dependabot.yml
@@ -28,6 +28,17 @@ updates:
 # Uncomment the sections relevant to your project
 # ============================================================================
 
+# PHP / Composer
+# - package-ecosystem: "composer"
+#   directory: "/"
+#   schedule:
+#     interval: "weekly"
+#     day: "monday"
+#   groups:
+#     all-dependencies:
+#       patterns:
+#         - "*"
+
 # Go modules
 # - package-ecosystem: "gomod"
 #   directory: "/"


### PR DESCRIPTION
## Summary
- Adds a commented-out `composer` ecosystem block to `config-templates/dependabot.yml`, alongside the existing gomod/npm/pip/cargo opt-ins
- WordPress plugin consumers (the repo's primary audience per README) typically ship `composer.json`/`composer.lock` — `wp-lint.yml` already filters on those paths, so composer dep updates were the only gap in the template
- Same shape as the other language entries: weekly Monday cadence, `all-dependencies` group

## Test plan
- [ ] `yamllint config-templates/dependabot.yml` passes
- [ ] Verify a consumer can uncomment the block and Dependabot picks it up on its next run