### PR TITLE
ci: centralize Docker security workflows

### DIFF
--- a/.github/workflows/docker-security-build.yml
+++ b/.github/workflows/docker-security-build.yml
@@ -1,0 +1,113 @@
+---
+name: Docker Security Build
+
+"on":
+  workflow_call:
+    inputs:
+      context:
+        description: Docker build context.
+        type: string
+        default: "."
+      dockerfile-path:
+        description: Dockerfile path relative to the repository root.
+        type: string
+        default: Dockerfile
+      image-ref:
+        description: Local image reference used for scanning.
+        type: string
+        default: ""
+      build-args:
+        description: Multiline Docker build arguments.
+        type: string
+        default: ""
+      event-name:
+        description: Caller event name, usually github.event_name.
+        type: string
+        required: true
+      repository-private:
+        description: Whether the caller repository is private.
+        type: boolean
+        required: true
+      sarif-severity:
+        description: Severities uploaded to GitHub Security.
+        type: string
+        default: CRITICAL,HIGH,MEDIUM
+      summary-severity:
+        description: Severities shown in the pull request log summary.
+        type: string
+        default: CRITICAL,HIGH
+      scanners:
+        description: Trivy scanners to run.
+        type: string
+        default: vuln,secret
+      timeout-minutes:
+        description: Job timeout in minutes.
+        type: number
+        default: 30
+
+jobs:
+  security-scan:
+    name: Security scan
+    runs-on: ubuntu-latest
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    permissions:
+      contents: read
+      security-events: write
+    env:
+      IMAGE_REF: >-
+        ${{
+          inputs.image-ref != '' &&
+          inputs.image-ref ||
+          format('{0}:security-scan', github.repository)
+        }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build image for scanning
+        uses: docker/build-push-action@v7
+        with:
+          context: ${{ inputs.context }}
+          file: ${{ inputs.dockerfile-path }}
+          push: false
+          pull: true
+          load: true
+          tags: ${{ env.IMAGE_REF }}
+          build-args: ${{ inputs.build-args }}
+
+      - name: Trivy SARIF report
+        if: >-
+          inputs.event-name != 'pull_request' &&
+          inputs.repository-private == false
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: ${{ env.IMAGE_REF }}
+          format: sarif
+          output: trivy-results.sarif
+          severity: ${{ inputs.sarif-severity }}
+          scanners: ${{ inputs.scanners }}
+          ignore-unfixed: true
+          exit-code: "0"
+          limit-severities-for-sarif: true
+
+      - name: Upload Trivy results to GitHub Security
+        if: >-
+          inputs.event-name != 'pull_request' &&
+          inputs.repository-private == false
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: trivy-results.sarif
+
+      - name: Trivy high and critical summary
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: ${{ env.IMAGE_REF }}
+          format: table
+          severity: ${{ inputs.summary-severity }}
+          scanners: ${{ inputs.scanners }}
+          ignore-unfixed: true
+          exit-code: "0"

--- a/.github/workflows/docker-security-images.yml
+++ b/.github/workflows/docker-security-images.yml
@@ -1,0 +1,86 @@
+---
+name: Docker Security Images
+
+"on":
+  workflow_call:
+    inputs:
+      images-json:
+        description: >-
+          JSON array of images to scan. Each item supports name, image,
+          category, and optional pkg_types.
+        type: string
+        required: true
+      event-name:
+        description: Caller event name, usually github.event_name.
+        type: string
+        required: true
+      repository-private:
+        description: Whether the caller repository is private.
+        type: boolean
+        required: true
+      sarif-severity:
+        description: Severities uploaded to GitHub Security.
+        type: string
+        default: CRITICAL,HIGH
+      summary-severity:
+        description: Severities shown in the pull request log summary.
+        type: string
+        default: CRITICAL,HIGH
+      scanners:
+        description: Trivy scanners to run.
+        type: string
+        default: vuln,secret
+      timeout-minutes:
+        description: Job timeout in minutes.
+        type: number
+        default: 15
+
+jobs:
+  security-scan:
+    name: Security scan (${{ matrix.image.name }})
+    runs-on: ubuntu-latest
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    permissions:
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        image: ${{ fromJSON(inputs.images-json) }}
+
+    steps:
+      - name: Trivy SARIF report
+        if: >-
+          inputs.event-name != 'pull_request' &&
+          inputs.repository-private == false
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: ${{ matrix.image.image }}
+          format: sarif
+          output: trivy-results.sarif
+          severity: ${{ inputs.sarif-severity }}
+          scanners: ${{ inputs.scanners }}
+          vuln-type: ${{ matrix.image.pkg_types || 'os,library' }}
+          ignore-unfixed: true
+          exit-code: "0"
+          limit-severities-for-sarif: true
+
+      - name: Upload Trivy results to GitHub Security
+        if: >-
+          inputs.event-name != 'pull_request' &&
+          inputs.repository-private == false
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: trivy-results.sarif
+          category: ${{ matrix.image.category }}
+
+      - name: Trivy high and critical summary
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: ${{ matrix.image.image }}
+          format: table
+          severity: ${{ inputs.summary-severity }}
+          scanners: ${{ inputs.scanners }}
+          vuln-type: ${{ matrix.image.pkg_types || 'os,library' }}
+          ignore-unfixed: true
+          exit-code: "0"

--- a/README.md
+++ b/README.md
@@ -22,16 +22,13 @@ cp config-templates/phpcs.xml.dist         ./   # WordPress plugin baseline
 | Workflow | Purpose | Fails on |
 |----------|---------|----------|
 | docker-quality | Dockerfile, YAML and Compose linting | Lint errors |
-| docker-security | Vulnerability scanning (Trivy) | CRITICAL CVEs |
+| docker-security | Thin caller for centralized Trivy scanning | Never; reports only |
 | shell-quality | ShellCheck (only on .sh changes) | Lint errors |
 
 ### Customization
 
-**Dockerfile not in root?**
-```yaml
-env:
-  DOCKERFILE_PATH: "docker/Dockerfile"
-```
+**Dockerfile not in root?** Call `docker-security-build.yml` directly and pass
+`dockerfile-path`; see the reusable workflow section below.
 
 **Adjust Hadolint rules?** Edit `.hadolint.yaml`, not the workflow.
 
@@ -59,7 +56,104 @@ The baseline locks down `WordPress-Extra` + `WordPress-Docs` + `PHPCompatibility
 
 ## Reusable workflows
 
-Call from the consumer repo's own `.github/workflows/` files. Pinning to the moving major tag (`@v2`) follows template fixes automatically; pinning to a patch tag (`@v2.0.0`) freezes.
+Call from the consumer repo's own `.github/workflows/` files. Most reusable
+workflows should pin to the moving major tag (`@v2`) so template fixes follow
+automatically, or to a patch tag (`@v2.0.0`) to freeze. The Docker security
+callers currently pin to `@main` because the whole point is to absorb scanning
+policy updates centrally without rolling every repository.
+
+### `docker-security-build.yml` - reusable Docker image scan
+
+Builds the caller repository's Docker image locally and scans it with Trivy.
+SARIF is uploaded to GitHub Security only for public non-PR runs; pull requests
+and private repositories still get a non-blocking high/critical table summary.
+
+```yaml
+name: Docker Security
+on:
+  push: { branches: [main] }
+  pull_request:
+  schedule:
+    - cron: "0 4 * * 0"
+  workflow_dispatch:
+permissions:
+  contents: read
+  security-events: write
+jobs:
+  security:
+    uses: oszuidwest/.github-templates/.github/workflows/docker-security-build.yml@main
+    with:
+      event-name: ${{ github.event_name }}
+      repository-private: ${{ github.event.repository.private }}
+```
+
+Inputs:
+
+| Input | Type | Required | Default | Notes |
+|-------|------|----------|---------|-------|
+| `context` | string | no | `.` | Docker build context. |
+| `dockerfile-path` | string | no | `Dockerfile` | Dockerfile path relative to repo root. |
+| `image-ref` | string | no | `<owner>/<repo>:security-scan` | Local image ref used by Trivy. |
+| `build-args` | string | no | `''` | Multiline Docker build args. |
+| `event-name` | string | yes | n/a | Pass `${{ github.event_name }}` from the caller. |
+| `repository-private` | boolean | yes | n/a | Pass `${{ github.event.repository.private }}`. |
+| `sarif-severity` | string | no | `CRITICAL,HIGH,MEDIUM` | Severities uploaded to GitHub Security. |
+| `summary-severity` | string | no | `CRITICAL,HIGH` | Severities shown in logs. |
+| `scanners` | string | no | `vuln,secret` | Trivy scanners. |
+| `timeout-minutes` | number | no | `30` | Job timeout. |
+
+Example for a non-root Dockerfile with build args:
+
+```yaml
+jobs:
+  security:
+    uses: oszuidwest/.github-templates/.github/workflows/docker-security-build.yml@main
+    with:
+      dockerfile-path: docker/Dockerfile
+      build-args: |
+        TOOL=odr-padenc
+        VERSION=${{ needs.env.outputs.odr-padenc-version }}
+      event-name: ${{ github.event_name }}
+      repository-private: ${{ github.event.repository.private }}
+```
+
+### `docker-security-images.yml` - reusable existing image scan
+
+Scans one or more existing image references. Use this for deployment repos that
+pin upstream images in Compose instead of building a local Dockerfile.
+
+```yaml
+jobs:
+  images:
+    runs-on: ubuntu-latest
+    outputs:
+      images-json: ${{ steps.images.outputs.images-json }}
+    steps:
+      - uses: actions/checkout@v6
+      - id: images
+        run: |
+          IMAGE="$(awk '$2 ~ /^example:/ { print $2; exit }' docker-compose.yml)"
+          echo "images-json=$(jq -cn --arg image "$IMAGE" \
+            '[{name:"app", image:$image, category:"container-app"}]')" \
+            >> "$GITHUB_OUTPUT"
+
+  security:
+    needs: images
+    uses: oszuidwest/.github-templates/.github/workflows/docker-security-images.yml@main
+    with:
+      images-json: ${{ needs.images.outputs.images-json }}
+      event-name: ${{ github.event_name }}
+      repository-private: ${{ github.event.repository.private }}
+```
+
+`images-json` is a JSON array. Each entry supports:
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| `name` | yes | Matrix display name. |
+| `image` | yes | Image reference for Trivy. |
+| `category` | yes | SARIF category, e.g. `container-caddy`. |
+| `pkg_types` | no | Trivy package types. Defaults to `os,library`; use `os` for OS-only scans. |
 
 ### `go-ci.yml` - Go CI
 

--- a/workflow-templates/docker-security.yml
+++ b/workflow-templates/docker-security.yml
@@ -8,72 +8,14 @@ name: Docker Security
   schedule:
     - cron: "0 4 * * 0"
   workflow_dispatch:
-  workflow_call:
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
 
 permissions:
   contents: read
   security-events: write
 
-env:
-  DOCKERFILE_PATH: Dockerfile
-  IMAGE_REF: ${{ github.repository }}:security-scan
-
 jobs:
-  security-scan:
-    name: Security scan
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
-      - name: Build image for scanning
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: ${{ env.DOCKERFILE_PATH }}
-          push: false
-          pull: true
-          load: true
-          tags: ${{ env.IMAGE_REF }}
-
-      - name: Trivy SARIF report
-        if: >-
-          github.event_name != 'pull_request' &&
-          github.event.repository.private == false
-        uses: aquasecurity/trivy-action@v0.36.0
-        with:
-          image-ref: ${{ env.IMAGE_REF }}
-          format: sarif
-          output: trivy-results.sarif
-          severity: CRITICAL,HIGH,MEDIUM
-          scanners: vuln,secret
-          ignore-unfixed: true
-          exit-code: "0"
-          limit-severities-for-sarif: true
-
-      - name: Upload Trivy results to GitHub Security
-        if: >-
-          github.event_name != 'pull_request' &&
-          github.event.repository.private == false
-        uses: github/codeql-action/upload-sarif@v4
-        with:
-          sarif_file: trivy-results.sarif
-
-      - name: Trivy high and critical summary
-        uses: aquasecurity/trivy-action@v0.36.0
-        with:
-          image-ref: ${{ env.IMAGE_REF }}
-          format: table
-          severity: CRITICAL,HIGH
-          scanners: vuln,secret
-          ignore-unfixed: true
-          exit-code: "0"
+  security:
+    uses: oszuidwest/.github-templates/.github/workflows/docker-security-build.yml@main  # yamllint disable-line rule:line-length
+    with:
+      event-name: ${{ github.event_name }}
+      repository-private: ${{ github.event.repository.private }}


### PR DESCRIPTION
## Summary

- add reusable Docker security workflows for locally built images and existing image references
- turn the copy-paste Docker Security template into a thin caller
- document the centralized Docker security workflow contracts and migration path

## Notes

Docker Security callers intentionally use `@main` so future scanning policy updates can land centrally without rolling every repository again.

## Validation

- `yamllint` on all changed Docker Security workflows
- Ruby YAML parse check on all changed Docker Security workflows
- `actionlint` on each changed Docker Security workflow
- `git diff --check`
- Compose image JSON generation tested for `zw-transfer` and `zw-transfer-old`
- `build.env` loading tested for `zwfm-odrbuilds`
