### PR TITLE
fix(release): gate manual tag rebuilds

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -96,15 +96,22 @@ jobs:
           GOVULNCHECK_OVERRIDE: ${{ inputs.govulncheck-version }}
           STATICCHECK_OVERRIDE: ${{ inputs.staticcheck-version }}
         run: |
-          deadcode_v="${DEADCODE_OVERRIDE:-$(go list -m -f '{{.Version}}' golang.org/x/tools)}"
-          govulncheck_v="${GOVULNCHECK_OVERRIDE:-$(go list -m -f '{{.Version}}' golang.org/x/vuln)}"
-          staticcheck_v="${STATICCHECK_OVERRIDE:-$(go list -m -f '{{.Version}}' honnef.co/go/tools)}"
+          mod_v() {
+            go list -m -f '{{.Version}}' "$1"
+          }
+
+          deadcode_v="${DEADCODE_OVERRIDE:-$(mod_v golang.org/x/tools)}"
+          govulncheck_v="${GOVULNCHECK_OVERRIDE:-$(mod_v golang.org/x/vuln)}"
+          staticcheck_v="${STATICCHECK_OVERRIDE:-$(mod_v honnef.co/go/tools)}"
           {
             echo "deadcode=$deadcode_v"
             echo "govulncheck=$govulncheck_v"
             echo "staticcheck=$staticcheck_v"
           } >> "$GITHUB_OUTPUT"
-          echo "Resolved: deadcode=$deadcode_v govulncheck=$govulncheck_v staticcheck=$staticcheck_v"
+          echo "Resolved:"
+          echo "  deadcode=$deadcode_v"
+          echo "  govulncheck=$govulncheck_v"
+          echo "  staticcheck=$staticcheck_v"
 
       - name: Install Go analysis tools
         env:

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -90,6 +90,7 @@ jobs:
         env:
           INPUT_VERSION: ${{ inputs.version }}
           EVENT_NAME: ${{ github.event_name }}
+          GITHUB_REF: ${{ github.ref }}
         run: |
           if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             if [ -z "$INPUT_VERSION" ]; then
@@ -109,18 +110,32 @@ jobs:
               echo "version=$VERSION" >> "$GITHUB_OUTPUT"
               echo "is_release=true" >> "$GITHUB_OUTPUT"
             fi
+          elif [ "$EVENT_NAME" = "push" ]; then
+            case "$GITHUB_REF" in
+              refs/tags/*)
+                echo "version=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+                echo "is_release=true" >> "$GITHUB_OUTPUT"
+                ;;
+              *)
+                echo "::error::Push on $GITHUB_REF is not a tag ref."
+                echo "::error::This workflow releases tag pushes only."
+                exit 1
+                ;;
+            esac
           else
-            echo "version=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
-            echo "is_release=true" >> "$GITHUB_OUTPUT"
+            echo "::error::Unsupported event '$EVENT_NAME'."
+            echo "::error::Supported triggers: tag push, workflow_dispatch."
+            exit 1
           fi
 
       - name: Create or check out version tag (manual release)
         if: >-
-          github.event_name != 'push' &&
+          github.event_name == 'workflow_dispatch' &&
           steps.version.outputs.is_release == 'true'
         env:
           VERSION: ${{ steps.version.outputs.version }}
           ALLOW_TAG_REBUILD: ${{ inputs.allow-tag-rebuild }}
+          GITHUB_SHA: ${{ github.sha }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -145,6 +160,7 @@ jobs:
 
       - name: Resolve build commit
         id: target
+        # HEAD, not github.sha: the previous step may have checked out the tag.
         run: echo "commit=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - uses: actions/setup-go@v6

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -34,6 +34,13 @@ on:
           Accepts "edge", "vX.Y.Z", or "X.Y.Z". Leave empty for tag pushes.
         type: string
         default: ''
+      allow-tag-rebuild:
+        description: >-
+          Allow workflow_dispatch to rebuild a pre-existing tag when that tag
+          points at a different commit than the workflow dispatch ref. Keep
+          false so caller `needs:` gates cover the commit that is released.
+        type: boolean
+        default: false
       release-body:
         description: >-
           Optional release-notes prefix prepended to auto-generated notes.
@@ -54,6 +61,11 @@ on:
           runs. Gate downstream Docker publish jobs on this so edge builds
           stay artifacts-only.
         value: ${{ jobs.release.outputs.is_release }}
+      commit:
+        description: >-
+          Resolved build commit SHA. For manual rebuilds with allow-tag-rebuild
+          set, this can differ from `github.sha`.
+        value: ${{ jobs.release.outputs.commit }}
 
 permissions:
   contents: read
@@ -66,16 +78,12 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.version }}
       is_release: ${{ steps.version.outputs.is_release }}
+      commit: ${{ steps.target.outputs.commit }}
 
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-
-      - uses: actions/setup-go@v6
-        with:
-          go-version-file: 'go.mod'
-          cache: true
 
       - name: Determine version
         id: version
@@ -106,26 +114,46 @@ jobs:
             echo "is_release=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Download dependencies
-        run: go mod download
-
       - name: Create or check out version tag (manual release)
         if: >-
           github.event_name != 'push' &&
           steps.version.outputs.is_release == 'true'
         env:
           VERSION: ${{ steps.version.outputs.version }}
+          ALLOW_TAG_REBUILD: ${{ inputs.allow-tag-rebuild }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           if git rev-parse -q --verify "refs/tags/$VERSION" >/dev/null; then
+            TAG_SHA=$(git rev-list -n 1 "refs/tags/$VERSION")
+            if [ "$TAG_SHA" != "$GITHUB_SHA" ]; then
+              if [ "$ALLOW_TAG_REBUILD" != "true" ]; then
+                echo "::error::Tag $VERSION points to $TAG_SHA."
+                echo "::error::This workflow was dispatched at $GITHUB_SHA."
+                echo "::error::Caller gates run against the dispatch commit."
+                echo "::error::Set allow-tag-rebuild: true to rebuild it."
+                exit 1
+              fi
+            fi
             echo "Tag $VERSION already exists; checking out that tag."
           else
             git tag "$VERSION"
             git push origin "refs/tags/$VERSION"
           fi
-          # End on the tag commit so COMMIT ldflag and downstream Docker build match.
+          # End on the tag commit so COMMIT and downstream Docker build match.
           git checkout "refs/tags/$VERSION"
+
+      - name: Resolve build commit
+        id: target
+        run: echo "commit=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
+      - name: Download dependencies
+        run: go mod download
 
       - name: Build binaries
         env:
@@ -134,10 +162,9 @@ jobs:
           LDFLAGS_TARGET: ${{ inputs.ldflags-target }}
           BUILD_MATRIX: ${{ inputs.build-matrix }}
           MAIN_PACKAGE: ${{ inputs.main-package }}
+          COMMIT: ${{ steps.target.outputs.commit }}
         run: |
           mkdir -p dist
-          # HEAD, not github.sha: previous step may have checked out the tag.
-          COMMIT=$(git rev-parse HEAD)
           BUILD_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
           echo "$BUILD_MATRIX" | jq -c '.[]' | while read -r entry; do

--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ Inputs:
 | `build-matrix` | string | yes | n/a | JSON array of `{os, arch, arm?}` build targets. |
 | `main-package` | string | no | `.` | Set to `./cmd/foo` for non-root commands. |
 | `version` | string | no | `''` | Forward the caller's `workflow_dispatch` input; leave empty for tag pushes. |
+| `allow-tag-rebuild` | boolean | no | `false` | Permit a manual rebuild of a pre-existing tag whose commit differs from the dispatch ref. |
 | `release-body` | string | no | `''` | Optional markdown prepended to generated release notes. |
 
 Outputs:
@@ -223,8 +224,16 @@ Outputs:
 |--------|-------|
 | `version` | Resolved release version. `vX.Y.Z` for tagged runs, `edge-<short-sha>` for edge. |
 | `is_release` | `'true'` for tagged releases (including prereleases), `'false'` for edge. Gate downstream Docker publish on this. |
+| `commit` | Resolved build commit SHA. Usually matches `github.sha`; differs only for explicit tag rebuilds. |
 
 **LDFLAGS contract:** the workflow injects PascalCase symbols `Version`, `Commit`, `BuildTime` at the package path you pass in `ldflags-target`. The Go package must declare those exact identifiers (e.g. `var Version, Commit, BuildTime string`). Lowercase names (`version`, `buildTime`) are not patched.
+
+For manual releases, `version: vX.Y.Z` creates the tag on the dispatch commit
+when it does not already exist. If the tag already exists, the workflow only
+reuses it by default when it points at the same commit as the dispatch ref. This
+keeps caller-side `needs:` gates aligned with the binaries that are published.
+Set `allow-tag-rebuild: true` only when intentionally rebuilding an existing
+tag from its original commit.
 
 #### Releasing with a Docker image
 
@@ -410,7 +419,13 @@ jobs:
       contents: write
 ```
 
-The custom job lives in the consumer repo, the template stays small, and `needs:` short-circuits the release if the gate fails.
+The custom job lives in the consumer repo, the template stays small, and
+`needs:` short-circuits the release if the gate fails. On manual releases of an
+existing `vX.Y.Z` tag, the release workflow also verifies that the tag points at
+the same commit as the dispatch ref. That prevents a gate on `main` from
+accidentally approving binaries rebuilt from an older tag. If you must rebuild
+an existing tag, set `allow-tag-rebuild: true` on the release job and treat that
+run as an explicit bypass of caller-side gates for the tag commit.
 
 ## Maintenance contract
 

--- a/README.md
+++ b/README.md
@@ -235,6 +235,10 @@ keeps caller-side `needs:` gates aligned with the binaries that are published.
 Set `allow-tag-rebuild: true` only when intentionally rebuilding an existing
 tag from its original commit.
 
+Supported triggers are tag pushes (`refs/tags/*`) and `workflow_dispatch`. Any
+other event — including branch pushes, `schedule`, and `release` — fails fast
+instead of being treated as a release.
+
 #### Releasing with a Docker image
 
 v2 dropped the nested docker job. Compose with `docker-publish.yml` from a second job in the caller workflow, gated on the release outputs:


### PR DESCRIPTION
## Analysis

Issue #34 is valid. In the current `go-release.yml`, a manual `workflow_dispatch` run can pass caller-side `needs:` gates on the dispatch commit, then build and publish from an already existing tag that points at another commit. That means the checks and the released binaries are not necessarily tied to the same source.

A reusable workflow output alone would not fix that path: outputs from the release job are only available after the job has already run, so caller-side pre-release gates in the same workflow cannot use them to protect the release job before it starts.

## Changes

- Add `allow-tag-rebuild` to `go-release.yml`, defaulting to `false`.
- For manual releases of pre-existing tags, fail when the tag commit differs from `github.sha` unless `allow-tag-rebuild: true` is explicitly set.
- Move `setup-go` and `go mod download` after tag creation/checkout so the Go version and dependency context come from the same commit that is built.
- Add a `commit` output for downstream observability of the resolved build commit.
- Document the new manual-tag behavior and the effect on caller-side `needs:` gates.
- Wrap existing long `go-ci.yml` shell lines so the documented repo-wide yamllint command exits cleanly.

## Compatibility

Normal tag pushes, edge builds, and manual releases that create a new tag keep the same behavior. The only default behavior change is that manual rebuilds of an existing tag from a different dispatch commit now stop instead of silently publishing a commit that the caller gates did not verify. Intentional rebuilds can opt in with `allow-tag-rebuild: true`.

Closes #34.

## Validation

- `git diff --check`
- `yamllint .github/workflows workflow-templates config-templates` exits 0; it still reports the repo's existing `on:` truthy warnings.
- `actionlint .github/workflows/*.yml workflow-templates/*.yml`
- Local Git simulation for the manual tag guard:
  - existing tag on a different commit fails without opt-in
  - existing tag on a different commit passes with `allow-tag-rebuild: true` and checks out the tag
  - existing tag on the same commit passes without opt-in
