### PR TITLE
feat(go-release): support per-target ldflags in build matrix

### DIFF
--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -22,6 +22,11 @@ name: Go Release
         description: >-
           JSON array of build targets, e.g.
           [{"os":"linux","arch":"amd64"},{"os":"linux","arch":"arm"}].
+          Entries accept an optional `ldflags` string appended verbatim to
+          that target's `-ldflags` after the Version, Commit, and BuildTime
+          symbols, e.g. {"os":"windows","arch":"amd64",
+          "ldflags":"-H windowsgui"}. Entries without `ldflags` build with
+          only the injected symbols.
         type: string
         required: true
       main-package:
@@ -48,14 +53,6 @@ name: Go Release
           etc. When empty, only auto-generated notes are used.
         type: string
         default: ''
-      extra-ldflags-per-os:
-        description: >-
-          Optional JSON object mapping GOOS to additional `-ldflags` values
-          appended verbatim to that OS's build after the Version, Commit, and
-          BuildTime symbols. Values must be strings a plain `go build
-          -ldflags=` accepts. Missing keys mean no extras for that OS.
-        type: string
-        default: '{}'
     outputs:
       version:
         description: >-
@@ -187,7 +184,6 @@ jobs:
           BUILD_MATRIX: ${{ inputs.build-matrix }}
           MAIN_PACKAGE: ${{ inputs.main-package }}
           COMMIT: ${{ steps.target.outputs.commit }}
-          EXTRA_LDFLAGS_PER_OS: ${{ inputs.extra-ldflags-per-os }}
         run: |
           mkdir -p dist
           BUILD_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
@@ -207,12 +203,7 @@ jobs:
             LDFLAGS="$LDFLAGS -X ${LDFLAGS_TARGET}.Version=${VERSION}"
             LDFLAGS="$LDFLAGS -X ${LDFLAGS_TARGET}.Commit=${COMMIT}"
             LDFLAGS="$LDFLAGS -X ${LDFLAGS_TARGET}.BuildTime=${BUILD_TIME}"
-
-            EXTRA=$(echo "$EXTRA_LDFLAGS_PER_OS" \
-              | jq -r --arg os "$GOOS" '.[$os] // ""')
-            if [ -n "$EXTRA" ]; then
-              LDFLAGS="$LDFLAGS $EXTRA"
-            fi
+            LDFLAGS="$LDFLAGS $(echo "$entry" | jq -r '.ldflags // ""')"
 
             env GOOS="$GOOS" GOARCH="$GOARCH" GOARM="$GOARM" CGO_ENABLED=0 \
               go build \

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -208,7 +208,8 @@ jobs:
             LDFLAGS="$LDFLAGS -X ${LDFLAGS_TARGET}.Commit=${COMMIT}"
             LDFLAGS="$LDFLAGS -X ${LDFLAGS_TARGET}.BuildTime=${BUILD_TIME}"
 
-            EXTRA=$(echo "$EXTRA_LDFLAGS_PER_OS" | jq -r --arg os "$GOOS" '.[$os] // ""')
+            EXTRA=$(echo "$EXTRA_LDFLAGS_PER_OS" \
+              | jq -r --arg os "$GOOS" '.[$os] // ""')
             if [ -n "$EXTRA" ]; then
               LDFLAGS="$LDFLAGS $EXTRA"
             fi

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -48,6 +48,14 @@ name: Go Release
           etc. When empty, only auto-generated notes are used.
         type: string
         default: ''
+      extra-ldflags-per-os:
+        description: >-
+          Optional JSON object mapping GOOS to additional `-ldflags` values
+          appended verbatim to that OS's build after the Version, Commit, and
+          BuildTime symbols. Values must be strings a plain `go build
+          -ldflags=` accepts. Missing keys mean no extras for that OS.
+        type: string
+        default: '{}'
     outputs:
       version:
         description: >-
@@ -179,6 +187,7 @@ jobs:
           BUILD_MATRIX: ${{ inputs.build-matrix }}
           MAIN_PACKAGE: ${{ inputs.main-package }}
           COMMIT: ${{ steps.target.outputs.commit }}
+          EXTRA_LDFLAGS_PER_OS: ${{ inputs.extra-ldflags-per-os }}
         run: |
           mkdir -p dist
           BUILD_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
@@ -198,6 +207,11 @@ jobs:
             LDFLAGS="$LDFLAGS -X ${LDFLAGS_TARGET}.Version=${VERSION}"
             LDFLAGS="$LDFLAGS -X ${LDFLAGS_TARGET}.Commit=${COMMIT}"
             LDFLAGS="$LDFLAGS -X ${LDFLAGS_TARGET}.BuildTime=${BUILD_TIME}"
+
+            EXTRA=$(echo "$EXTRA_LDFLAGS_PER_OS" | jq -r --arg os "$GOOS" '.[$os] // ""')
+            if [ -n "$EXTRA" ]; then
+              LDFLAGS="$LDFLAGS $EXTRA"
+            fi
 
             env GOOS="$GOOS" GOARCH="$GOARCH" GOARM="$GOARM" CGO_ENABLED=0 \
               go build \

--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ Inputs:
 | `version` | string | no | `''` | Forward the caller's `workflow_dispatch` input; leave empty for tag pushes. |
 | `allow-tag-rebuild` | boolean | no | `false` | Permit a manual rebuild of a pre-existing tag whose commit differs from the dispatch ref. |
 | `release-body` | string | no | `''` | Optional markdown prepended to generated release notes. |
+| `extra-ldflags-per-os` | string | no | `'{}'` | JSON object mapping GOOS to extra `-ldflags` appended after the injected symbols, e.g. `'{"windows":"-H windowsgui"}'`. |
 
 Outputs:
 

--- a/README.md
+++ b/README.md
@@ -212,12 +212,11 @@ Inputs:
 |-------|------|----------|---------|-------|
 | `project-name` | string | yes | n/a | Binary basename and edge artifact prefix. |
 | `ldflags-target` | string | yes | n/a | Package path containing `Version`, `Commit`, and `BuildTime`. |
-| `build-matrix` | string | yes | n/a | JSON array of `{os, arch, arm?}` build targets. |
+| `build-matrix` | string | yes | n/a | JSON array of `{os, arch, arm?, ldflags?}` build targets; optional `ldflags` is appended after the injected symbols, e.g. `{"os":"windows","arch":"amd64","ldflags":"-H windowsgui"}`. |
 | `main-package` | string | no | `.` | Set to `./cmd/foo` for non-root commands. |
 | `version` | string | no | `''` | Forward the caller's `workflow_dispatch` input; leave empty for tag pushes. |
 | `allow-tag-rebuild` | boolean | no | `false` | Permit a manual rebuild of a pre-existing tag whose commit differs from the dispatch ref. |
 | `release-body` | string | no | `''` | Optional markdown prepended to generated release notes. |
-| `extra-ldflags-per-os` | string | no | `'{}'` | JSON object mapping GOOS to extra `-ldflags` appended after the injected symbols, e.g. `'{"windows":"-H windowsgui"}'`. |
 
 Outputs:
 


### PR DESCRIPTION
## Summary
- Adds optional `ldflags` on each `build-matrix` entry so callers can append target-specific Go linker flags after the injected Version, Commit, and BuildTime symbols.
- Documents the Windows GUI use case with `"ldflags":"-H windowsgui"`.
- Replaces the unreleased `extra-ldflags-per-os` branch-only approach with per-target configuration inside the existing build matrix.

## Compatibility
- Existing `@v2` callers are unaffected because `ldflags` is optional and existing matrix entries continue to work unchanged.
- `extra-ldflags-per-os` was introduced only on this feature branch and has not shipped in the current `v2` tag.
- Release as a minor version, e.g. `v2.5.0`, then move the floating `v2` tag to the merge commit.

## Validation
- [x] `git diff --check`
- [x] `yamllint .github/workflows workflow-templates config-templates`
- [x] `actionlint .github/workflows/*.yml workflow-templates/*.yml`
- [ ] Consumer smoke test with a Windows matrix target using `"ldflags":"-H windowsgui"`
