### PR TITLE
feat(go-ci): count test functions as deadcode roots

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -123,9 +123,13 @@ jobs:
           go install "golang.org/x/vuln/cmd/govulncheck@${GOVULNCHECK_VERSION}"
           go install "honnef.co/go/tools/cmd/staticcheck@${STATICCHECK_VERSION}"
 
+      # -test counts test functions as reachability roots, so code that is
+      # only reachable from platform-tagged files plus tests on this
+      # platform is not a false positive. Trade-off: dead production code
+      # that still has tests is not reported.
       - name: Check for dead code
         run: |
-          deadcode_output=$(deadcode ./...)
+          deadcode_output=$(deadcode -test ./...)
           if [ -n "$deadcode_output" ]; then
             echo "$deadcode_output"
             exit 1


### PR DESCRIPTION
## Summary

Run the dead-code check as `deadcode -test ./...` so test functions count as reachability roots.

## Why

Production code that, on the linux CI build, is only reachable from platform-tagged files plus tests was flagged as dead. Example in zwfm-encoder: moving the Windows log `rollingWriter` to a platform-neutral file so its rotation and failure-recovery logic can get unit tests on linux CI. Without `-test`, deadcode reports such code as dead because its only linux-side callers are tests.

## Trade-off

Dead production code that still has lingering tests is no longer reported. Accepted for simplicity: no per-consumer input, and the lingering tests themselves document what to clean up.