### PR TITLE
feat(docker-security): add category input to docker-security-build

### DIFF
--- a/.github/workflows/docker-security-build.yml
+++ b/.github/workflows/docker-security-build.yml
@@ -20,6 +20,13 @@ name: Docker Security Build
         description: Multiline Docker build arguments.
         type: string
         default: ""
+      category:
+        description: >-
+          SARIF category for the GitHub Security upload. Set a unique value
+          per image when one repository scans multiple images, otherwise the
+          uploads overwrite each other. Empty means the codeql-action default.
+        type: string
+        default: ""
       event-name:
         description: Caller event name, usually github.event_name.
         type: string
@@ -103,6 +110,7 @@ jobs:
         uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: trivy-results.sarif
+          category: ${{ inputs.category }}
 
       - name: Trivy high and critical summary
         uses: aquasecurity/trivy-action@v0.36.0

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Inputs:
 | `dockerfile-path` | string | no | `Dockerfile` | Dockerfile path relative to repo root. |
 | `image-ref` | string | no | `<owner>/<repo>:security-scan` | Local image ref used by Trivy. |
 | `build-args` | string | no | `''` | Multiline Docker build args. |
+| `category` | string | no | `''` | SARIF upload category. Set a unique value per image when one repo scans multiple images; empty uses the codeql-action default. |
 | `event-name` | string | yes | n/a | Pass `${{ github.event_name }}` from the caller. |
 | `repository-private` | boolean | yes | n/a | Pass `${{ github.event.repository.private }}`. |
 | `sarif-severity` | string | no | `CRITICAL,HIGH,MEDIUM` | Severities uploaded to GitHub Security. |
@@ -115,6 +116,32 @@ jobs:
       build-args: |
         TOOL=odr-padenc
         VERSION=${{ needs.env.outputs.odr-padenc-version }}
+      event-name: ${{ github.event_name }}
+      repository-private: ${{ github.event.repository.private }}
+```
+
+When one Dockerfile produces multiple images (different build args), call the
+workflow with a matrix and give every image its own `category`. Without a
+unique category the SARIF uploads share one analysis and overwrite each other,
+so only the last-uploaded image is visible in the Security tab:
+
+```yaml
+jobs:
+  security:
+    name: ${{ matrix.image }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { image: odr-padenc, tool: odr-padenc, variant: "" }
+          - { image: odr-audioenc-full, tool: odr-audioenc, variant: full }
+    uses: oszuidwest/.github-templates/.github/workflows/docker-security-build.yml@main
+    with:
+      dockerfile-path: docker/Dockerfile
+      build-args: |
+        TOOL=${{ matrix.tool }}
+        VARIANT=${{ matrix.variant }}
+      category: security-scan-${{ matrix.image }}
       event-name: ${{ github.event_name }}
       repository-private: ${{ github.event.repository.private }}
 ```


### PR DESCRIPTION
## Summary

Adds an optional `category` input to the `docker-security-build.yml` reusable workflow, passed to `github/codeql-action/upload-sarif`.

## Why

When one repository builds multiple images from the same Dockerfile (e.g. zwfm-odrbuilds with padenc/audioenc-minimal/audioenc-full/dabmux), all SARIF uploads currently land in the same default category. GitHub treats them as one analysis, so each upload overwrites the previous one and only the last-scanned image is visible in the Security tab.

With a unique `category` per image, every image gets its own analysis and alerts are tracked per image.

## Consumer impact

None for existing consumers: the input is optional and defaults to `''`, which codeql-action treats as unset (current default category behavior). This is an additive minor change.

## Validation

- `yamllint .github/workflows/docker-security-build.yml`: clean
- `actionlint .github/workflows/docker-security-build.yml`: clean
- Consumer smoke test: oszuidwest/zwfm-odrbuilds PR (follows) calls this with a 4-image matrix

README updated with the new input and a matrix usage example.