### PR TITLE
fix(docker-security): build the scan image without layer cache

### DIFF
--- a/.github/workflows/docker-security-build.yml
+++ b/.github/workflows/docker-security-build.yml
@@ -85,8 +85,10 @@ jobs:
           load: true
           tags: ${{ env.IMAGE_REF }}
           build-args: ${{ inputs.build-args }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max,ignore-error=true
+          # No layer cache on purpose: cached RUN layers freeze package
+          # installs, so the scan keeps seeing stale packages and misses
+          # security updates that a fresh build would pull in.
+          no-cache: true
 
       - name: Trivy SARIF report
         if: >-

--- a/README.md
+++ b/README.md
@@ -67,8 +67,9 @@ policy updates centrally without rolling every repository.
 Builds the caller repository's Docker image locally and scans it with Trivy.
 SARIF is uploaded to GitHub Security only for public non-PR runs; pull requests
 and private repositories still get a non-blocking high/critical table summary.
-Docker layer cache is imported from GitHub Actions cache and exported
-best-effort after the build.
+The image is always built without layer cache: cached RUN layers freeze
+package installs, so a cached scan keeps reporting stale packages and misses
+security updates that a fresh build would pull in.
 
 ```yaml
 name: Docker Security


### PR DESCRIPTION
## Summary

Removes the GHA layer cache from `docker-security-build.yml` and builds the scan image with `no-cache: true`.

## Why

Cached RUN layers freeze package installs at the moment the cache entry was created. Concrete case in zwfm-odrbuilds: Debian published the ImageMagick fix (`deb13u11`) on July 6, but every scan since - including a manual rerun on July 11 - kept reporting the vulnerable `deb13u10`. The rerun completed in 70 seconds: a full cache hit that never touched the Debian mirrors. The Security tab showed 42 open alerts for a vulnerability that a fresh build would not have.

A security scan must reflect what a fresh build produces today, not what was built when the cache was primed. Freshness is the entire point of the weekly schedule.

## Consumer impact

Scan jobs lose the layer cache and get a few minutes slower per run. No input or permission changes.

## Validation

- `yamllint` / `actionlint`: clean
- Root-cause evidence: zwfm-odrbuilds run 29147225822 (70s cache-hit scan reporting deb13u10) vs run 29147226577 (uncached docker-build installing deb13u11 at the same moment)