### PR TITLE
build: bump Go to 1.26.5

### DIFF
--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module local/templates-tools
 
-go 1.25.0
+go 1.26.5
 
 tool (
 	golang.org/x/tools/cmd/deadcode


### PR DESCRIPTION
## Summary
- bump the tools module Go directive to `1.26.5`

## Checks
- `go mod tidy`
- `go mod verify`
- `go test ./...` was not applicable: the tools module has no packages