### PR TITLE
feat(wp): harden v2 workflows

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,42 @@
+---
+name: Workflow syntax
+
+"on":
+  push:
+    branches: [main]
+    paths:
+      - '.github/actions/**'
+      - '.github/workflows/**'
+      - 'workflow-templates/**'
+  pull_request:
+    paths:
+      - '.github/actions/**'
+      - '.github/workflows/**'
+      - 'workflow-templates/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  actionlint:
+    name: actionlint
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: '1.26.x'
+          cache: false
+
+      - name: Install actionlint
+        run: go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
+
+      - name: Validate workflows
+        run: actionlint -color .github/workflows/*.yml workflow-templates/*.yml

--- a/.github/workflows/wp-ci.yml
+++ b/.github/workflows/wp-ci.yml
@@ -1,10 +1,64 @@
 ---
-# Strict shape: zero inputs. PHP matrix, plugin-check, and i18n behavior are
-# fixed; the i18n job auto-detects via languages/*.pot.
+# PHP linting, static analysis, Plugin Check, and optional i18n validation.
 name: WP CI
 
 "on":
   workflow_call:
+    inputs:
+      composer-audit:
+        description: 'Run composer audit once on PHP 8.4.'
+        type: boolean
+        default: false
+      strict-composer-validation:
+        description: 'Pass --strict to composer validate.'
+        type: boolean
+        default: false
+      exact-pot-validation:
+        description: >-
+          Compare the complete generated POT after removing volatile headers.
+        type: boolean
+        default: false
+      pot-include:
+        description: 'Comma-separated paths included by wp i18n make-pot.'
+        type: string
+        default: ''
+      pot-exclude:
+        description: 'Comma-separated paths excluded by wp i18n make-pot.'
+        type: string
+        default: ''
+      plugin-check-build-dir:
+        description: 'Plugin build directory passed to Plugin Check.'
+        type: string
+        default: './'
+      plugin-check-slug:
+        description: 'Plugin slug override passed to Plugin Check.'
+        type: string
+        default: ''
+      plugin-check-exclude-files:
+        description: 'Newline-separated files excluded from Plugin Check.'
+        type: string
+        default: ''
+      plugin-check-exclude-directories:
+        description: 'Newline-separated directories excluded from Plugin Check.'
+        type: string
+        default: ''
+      plugin-check-exclude-checks:
+        description: 'Newline-separated Plugin Check checks to exclude.'
+        type: string
+        default: |-
+          late_escaping
+          plugin_review_phpcs
+          file_type
+          plugin_readme
+          plugin_updater
+      php-timeout-minutes:
+        description: 'Timeout for each PHP matrix job.'
+        type: number
+        default: 15
+      translations-timeout-minutes:
+        description: 'Timeout for the translations job.'
+        type: number
+        default: 10
 
 permissions:
   contents: read
@@ -13,6 +67,9 @@ jobs:
   php:
     name: PHP ${{ matrix.php }}
     runs-on: ubuntu-latest
+    timeout-minutes: ${{ inputs.php-timeout-minutes }}
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     strategy:
       fail-fast: false
       matrix:
@@ -28,13 +85,29 @@ jobs:
           tools: composer:v2, cs2pr
 
       - name: Validate PHP syntax
-        run: find . -maxdepth 1 -name '*.php' -exec php --syntax-check {} +
+        run: >-
+          find . -path './vendor' -prune -o -path './node_modules' -prune -o
+          -path './build' -prune -o -path './dist' -prune -o
+          -name '*.php' -type f -print0 | xargs -0 -n1 php --syntax-check
 
       - name: Validate composer.json
-        run: composer validate --no-check-publish
+        env:
+          STRICT: ${{ inputs.strict-composer-validation }}
+        run: |
+          args=(--no-check-publish)
+          if [ "$STRICT" = "true" ]; then
+            args+=(--strict)
+          fi
+          composer validate "${args[@]}"
 
       - name: Install dependencies
-        run: composer install --no-progress --prefer-dist --optimize-autoloader
+        run: >-
+          composer install --no-progress --prefer-dist --no-interaction
+          --optimize-autoloader
+
+      - name: Audit Composer dependencies
+        if: inputs.composer-audit && matrix.php == '8.4'
+        run: composer audit --locked --no-interaction
 
       - name: PHP_CodeSniffer
         run: |
@@ -49,16 +122,17 @@ jobs:
         if: matrix.php == '8.4'
         uses: wordpress/plugin-check-action@v1
         with:
-          exclude-checks: |
-            late_escaping
-            plugin_review_phpcs
-            file_type
-            plugin_readme
-            plugin_updater
+          build-dir: ${{ inputs.plugin-check-build-dir }}
+          slug: ${{ inputs.plugin-check-slug }}
+          exclude-files: ${{ inputs.plugin-check-exclude-files }}
+          exclude-directories: >-
+            ${{ inputs.plugin-check-exclude-directories }}
+          exclude-checks: ${{ inputs.plugin-check-exclude-checks }}
 
   translations:
     name: Translations
     runs-on: ubuntu-latest
+    timeout-minutes: ${{ inputs.translations-timeout-minutes }}
     steps:
       - uses: actions/checkout@v7
 
@@ -89,18 +163,40 @@ jobs:
       - name: Verify POT is up-to-date
         if: steps.detect.outputs.has_pot == 'true'
         env:
+          EXACT: ${{ inputs.exact-pot-validation }}
           POT_FILE: ${{ steps.detect.outputs.pot_file }}
+          POT_INCLUDE: ${{ inputs.pot-include }}
+          POT_EXCLUDE: ${{ inputs.pot-exclude }}
           SLUG: ${{ steps.detect.outputs.slug }}
         run: |
-          NEW_POT="languages/${SLUG}-new.pot"
-          wp i18n make-pot . "$NEW_POT" \
-            --slug="$SLUG" --domain="$SLUG" --skip-audit
+          tmp="$(mktemp -d)"
+          trap 'rm -rf "$tmp"' EXIT
+          NEW_POT="$tmp/generated.pot"
+          args=(--slug="$SLUG" --domain="$SLUG" --skip-audit)
+          if [ -n "$POT_INCLUDE" ]; then
+            args+=(--include="$POT_INCLUDE")
+          fi
+          if [ -n "$POT_EXCLUDE" ]; then
+            args+=(--exclude="$POT_EXCLUDE")
+          fi
+          wp i18n make-pot . "$NEW_POT" "${args[@]}"
+
+          if [ "$EXACT" = "true" ]; then
+            sed -E '/POT-Creation-Date:|X-Generator:/d' \
+              "$POT_FILE" > "$tmp/committed.stripped"
+            sed -E '/POT-Creation-Date:|X-Generator:/d' \
+              "$NEW_POT" > "$tmp/generated.stripped"
+            diff -u "$tmp/committed.stripped" "$tmp/generated.stripped"
+            echo "The complete POT file is up to date."
+            exit 0
+          fi
+
           comm -13 \
             <(grep "^msgid " "$POT_FILE" | sort) \
-            <(grep "^msgid " "$NEW_POT" | sort) > /tmp/missing.txt
-          if [ -s /tmp/missing.txt ]; then
+            <(grep "^msgid " "$NEW_POT" | sort) > "$tmp/missing.txt"
+          if [ -s "$tmp/missing.txt" ]; then
             echo "::error::Missing translation strings in $POT_FILE:"
-            cat /tmp/missing.txt
+            cat "$tmp/missing.txt"
             echo ""
             echo "Run: wp i18n make-pot . $POT_FILE --slug=$SLUG --domain=$SLUG"
             exit 1

--- a/.github/workflows/wp-js-ci.yml
+++ b/.github/workflows/wp-js-ci.yml
@@ -1,28 +1,64 @@
 ---
-# Strict shape: zero inputs. Node 24, npm ci, npm run lint.
-# Convention: consumer's package.json defines the lint script (typically biome).
+# Node-based WordPress plugin quality checks.
 name: WP JS CI
 
 "on":
   workflow_call:
+    inputs:
+      node-version:
+        description: 'Node version used when node-version-file is empty.'
+        type: string
+        default: '24'
+      node-version-file:
+        description: 'Optional Node version file, for example .nvmrc.'
+        type: string
+        default: ''
+      npm-audit:
+        description: 'Fail on high or critical npm advisories.'
+        type: boolean
+        default: false
+      lint-command:
+        description: 'Command used to lint and build JavaScript assets.'
+        type: string
+        default: 'npm run lint'
+      timeout-minutes:
+        description: 'Job timeout in minutes.'
+        type: number
+        default: 15
 
 permissions:
   contents: read
 
 jobs:
   lint:
-    name: Biome
+    name: Lint, build, and audit
     runs-on: ubuntu-latest
+    timeout-minutes: ${{ inputs.timeout-minutes }}
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v6
+      - name: Setup Node from version input
+        if: inputs.node-version-file == ''
+        uses: actions/setup-node@v6
         with:
-          node-version: "24"
+          node-version: ${{ inputs.node-version }}
+          cache: npm
+
+      - name: Setup Node from version file
+        if: inputs.node-version-file != ''
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: ${{ inputs.node-version-file }}
           cache: npm
 
       - name: Install dependencies
         run: npm ci
 
+      - name: Audit npm dependencies
+        if: inputs.npm-audit
+        run: npm audit --audit-level=high
+
       - name: Lint
-        run: npm run lint
+        env:
+          LINT_COMMAND: ${{ inputs.lint-command }}
+        run: bash -euo pipefail -c "$LINT_COMMAND"

--- a/.github/workflows/wp-release.yml
+++ b/.github/workflows/wp-release.yml
@@ -32,6 +32,7 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: write
     outputs:
@@ -81,8 +82,9 @@ jobs:
           VERSION: ${{ steps.version.outputs.version }}
           FORCE: ${{ inputs.force }}
         run: |
-          LATEST_TAG=$(git describe --tags \
-            "$(git rev-list --tags --max-count=1)" 2>/dev/null || echo "")
+          LATEST_TAG=$(git tag --list \
+            | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+)?$' \
+            | sort -V | tail -1 || true)
           # Compare bare versions: strip an optional leading 'v' from the tag
           # so a header value of "0.5.2" outranks an existing "v0.5.1" tag.
           # sort -V otherwise places the bare form before the v-prefixed one,
@@ -132,7 +134,9 @@ jobs:
 
       - name: Install production dependencies
         if: steps.decide.outputs.release_needed == 'true'
-        run: composer install --no-dev --optimize-autoloader
+        run: >-
+          composer install --no-dev --no-progress --prefer-dist
+          --no-interaction --optimize-autoloader
 
       - name: Compile translations
         if: steps.decide.outputs.release_needed == 'true'
@@ -180,20 +184,21 @@ jobs:
           ZIP="${SLUG}-${VERSION}.zip"
           (cd release && zip -r "../$ZIP" "$SLUG")
           ls -la "$ZIP"
+          shasum -a 256 "$ZIP" > "${ZIP}.sha256"
           echo "zip=$ZIP" >> "$GITHUB_OUTPUT"
 
       - name: Create GitHub release
         if: steps.decide.outputs.release_needed == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VERSION: ${{ steps.decide.outputs.version }}
-          ZIP: ${{ steps.package.outputs.zip }}
-        run: |
-          ARGS=("$VERSION" "$ZIP" --title "$VERSION" --generate-notes)
-          if [[ "$VERSION" == *-* ]]; then
-            ARGS+=(--prerelease)
-          fi
-          gh release create "${ARGS[@]}"
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ steps.decide.outputs.version }}
+          name: ${{ steps.decide.outputs.version }}
+          files: |
+            ${{ steps.package.outputs.zip }}
+            ${{ steps.package.outputs.zip }}.sha256
+          generate_release_notes: true
+          prerelease: >-
+            ${{ contains(steps.decide.outputs.version, '-') }}
 
       - name: Report skipped release
         if: steps.decide.outputs.release_needed != 'true'

--- a/.github/workflows/wp-tests.yml
+++ b/.github/workflows/wp-tests.yml
@@ -1,0 +1,80 @@
+---
+name: WP Tests
+
+"on":
+  workflow_call:
+    inputs:
+      php-versions:
+        description: 'JSON array of PHP versions to test.'
+        type: string
+        default: '["8.3", "8.4"]'
+      test-command:
+        description: 'Command used for regular test runs.'
+        type: string
+        default: 'composer test'
+      coverage-php:
+        description: 'PHP version that runs coverage; empty disables coverage.'
+        type: string
+        default: ''
+      coverage-command:
+        description: 'Command used for the coverage run.'
+        type: string
+        default: 'composer coverage'
+      coverage-artifact:
+        description: 'Coverage report uploaded as an artifact.'
+        type: string
+        default: 'coverage.xml'
+      timeout-minutes:
+        description: 'Timeout for each matrix job.'
+        type: number
+        default: 15
+
+permissions:
+  contents: read
+
+jobs:
+  phpunit:
+    name: PHPUnit (PHP ${{ matrix.php }})
+    runs-on: ubuntu-latest
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ${{ fromJSON(inputs.php-versions) }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: >-
+            ${{ matrix.php == inputs.coverage-php && 'xdebug' || 'none' }}
+          tools: composer:v2
+
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress --no-interaction
+
+      - name: Run tests
+        if: matrix.php != inputs.coverage-php
+        env:
+          TEST_COMMAND: ${{ inputs.test-command }}
+        run: bash -euo pipefail -c "$TEST_COMMAND"
+
+      - name: Run tests with coverage
+        if: inputs.coverage-php != '' && matrix.php == inputs.coverage-php
+        env:
+          COVERAGE_COMMAND: ${{ inputs.coverage-command }}
+        run: bash -euo pipefail -c "$COVERAGE_COMMAND"
+
+      - name: Upload coverage report
+        if: >-
+          inputs.coverage-php != '' &&
+          matrix.php == inputs.coverage-php &&
+          !cancelled()
+        uses: actions/upload-artifact@v7
+        with:
+          name: php-coverage-${{ matrix.php }}
+          path: ${{ inputs.coverage-artifact }}
+          retention-days: 14
+          if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ Shared GitHub Actions for repositories at oszuidwest. Two delivery models:
 cp workflow-templates/docker-quality.yml   .github/workflows/
 cp workflow-templates/docker-security.yml  .github/workflows/
 cp workflow-templates/shell-quality.yml    .github/workflows/
+cp workflow-templates/workflow-quality.yml .github/workflows/
+cp workflow-templates/wp-lint.yml           .github/workflows/
+cp workflow-templates/wp-js-lint.yml        .github/workflows/
+cp workflow-templates/wp-tests.yml          .github/workflows/
+cp workflow-templates/wp-release.yml        .github/workflows/
 
 # Config
 cp config-templates/.hadolint.yaml         ./
@@ -24,6 +29,11 @@ cp config-templates/phpcs.xml.dist         ./   # WordPress plugin baseline
 | docker-quality | Dockerfile, YAML and Compose linting | Lint errors |
 | docker-security | Thin caller for centralized Trivy scanning | Never; reports only |
 | shell-quality | ShellCheck (only on .sh changes) | Lint errors |
+| workflow-quality | GitHub Actions syntax validation | Actionlint errors |
+| wp-lint | PHP, static analysis, Plugin Check and translations | Quality errors |
+| wp-js-lint | npm audit plus the consumer's lint/build command | Quality errors |
+| wp-tests | PHPUnit matrix with optional coverage | Test or coverage errors |
+| wp-release | Thin caller for centralized WordPress releases | Release errors |
 
 ### Customization
 
@@ -335,7 +345,10 @@ Inputs:
 
 ### `wp-ci.yml` - WordPress plugin lint
 
-Strict shape, no inputs. PHP matrix `["8.3", "8.4"]`, fixed `wp-plugin-check` excludes, optional translations job that auto-runs when `languages/*.pot` exists.
+PHP matrix `["8.3", "8.4"]` with recursive syntax validation, Composer,
+PHP_CodeSniffer, PHPStan, Plugin Check, and an optional translations job that
+auto-runs when `languages/*.pot` exists. Existing v2 behavior remains the
+default; stricter validation and dependency auditing are opt-in.
 
 ```yaml
 name: Lint
@@ -347,17 +360,45 @@ permissions: { contents: read }
 jobs:
   lint:
     uses: oszuidwest/.github-templates/.github/workflows/wp-ci.yml@v2
+    with:
+      composer-audit: true
+      exact-pot-validation: true
+      strict-composer-validation: true
 ```
 
-The `php` job runs `php --syntax-check`, `composer validate`, `composer install`, `phpcs` (checkstyle/cs2pr), `phpstan` (checkstyle/cs2pr), and `wordpress/plugin-check-action@v1` once on PHP 8.4. Plugin-check excludes are fixed to `late_escaping`, `plugin_review_phpcs`, `file_type`, `plugin_readme`. Plugins that fail other checks fix it in code rather than configuring the workflow.
+The `php` job runs recursive `php --syntax-check`, `composer validate`,
+`composer install`, `phpcs` (checkstyle/cs2pr), `phpstan`
+(checkstyle/cs2pr), and `wordpress/plugin-check-action@v1` once on PHP 8.4.
+Plugin Check inputs allow consumers to provide their slug, build directory,
+and project-specific file or directory exclusions while retaining the shared
+default check exclusions.
 
 The `translations` job auto-detects `languages/*.pot`, runs `wp i18n make-pot` against a fresh copy, and fails on missing strings. Slug and domain are derived from the POT filename (e.g. `languages/foo.pot` -> slug+domain `foo`).
 
 Consumer requirements: `composer.json` declares `phpcs` and `phpstan` as dev dependencies; `phpcs.xml` (or `phpcs.xml.dist`) and `phpstan.neon` exist at repo root.
 
+Inputs:
+
+| Input | Type | Default | Notes |
+|-------|------|---------|-------|
+| `composer-audit` | boolean | `false` | Runs `composer audit --locked` once on PHP 8.4. |
+| `strict-composer-validation` | boolean | `false` | Adds `--strict` to `composer validate`. |
+| `exact-pot-validation` | boolean | `false` | Diffs the complete POT after removing volatile headers. |
+| `pot-include` | string | `''` | Comma-separated paths included by `wp i18n make-pot`. |
+| `pot-exclude` | string | `''` | Comma-separated paths excluded by `wp i18n make-pot`. |
+| `plugin-check-build-dir` | string | `./` | Plugin build directory passed to Plugin Check. |
+| `plugin-check-slug` | string | `''` | Plugin slug override passed to Plugin Check. |
+| `plugin-check-exclude-files` | string | `''` | Newline-separated excluded files. |
+| `plugin-check-exclude-directories` | string | `''` | Newline-separated excluded directories. |
+| `plugin-check-exclude-checks` | string | shared list | Overrides the shared excluded checks. |
+| `php-timeout-minutes` | number | `15` | Timeout for each PHP matrix job. |
+| `translations-timeout-minutes` | number | `10` | Timeout for the translations job. |
+
 ### `wp-js-ci.yml` - WordPress plugin JS lint
 
-Strict shape, no inputs. Node 24, `npm ci`, `npm run lint`. Convention: consumer's `package.json` defines `lint` (typically `biome check assets/`).
+Runs `npm ci` followed by an optional high-severity audit and the consumer's
+lint/build command. Node 24 remains the default; consumers can instead use a
+version file such as `.nvmrc`.
 
 ```yaml
 name: JS Lint
@@ -369,7 +410,50 @@ permissions: { contents: read }
 jobs:
   lint:
     uses: oszuidwest/.github-templates/.github/workflows/wp-js-ci.yml@v2
+    with:
+      npm-audit: true
 ```
+
+Inputs:
+
+| Input | Type | Default | Notes |
+|-------|------|---------|-------|
+| `node-version` | string | `24` | Used when `node-version-file` is empty. |
+| `node-version-file` | string | `''` | Optional file such as `.nvmrc`. |
+| `npm-audit` | boolean | `false` | Fails on high or critical npm advisories. |
+| `lint-command` | string | `npm run lint` | Consumer lint/build command. |
+| `timeout-minutes` | number | `15` | Job timeout. |
+
+### `wp-tests.yml` - WordPress plugin PHPUnit
+
+Runs a configurable PHP matrix. Coverage is disabled by default; set
+`coverage-php` to run the consumer's coverage command on one PHP version and
+upload the resulting report.
+
+```yaml
+name: Tests
+"on":
+  push: { branches: [main], paths: ['**/*.php', 'composer.*', 'tests/**'] }
+  pull_request: { paths: ['**/*.php', 'composer.*', 'tests/**'] }
+  workflow_dispatch:
+permissions: { contents: read }
+jobs:
+  phpunit:
+    uses: oszuidwest/.github-templates/.github/workflows/wp-tests.yml@v2
+    with:
+      coverage-php: '8.4'
+```
+
+Inputs:
+
+| Input | Type | Default | Notes |
+|-------|------|---------|-------|
+| `php-versions` | string | `["8.3", "8.4"]` | JSON PHP version array. |
+| `test-command` | string | `composer test` | Regular test command. |
+| `coverage-php` | string | `''` | Matrix version used for coverage; empty disables it. |
+| `coverage-command` | string | `composer coverage` | Coverage command. |
+| `coverage-artifact` | string | `coverage.xml` | Uploaded report path. |
+| `timeout-minutes` | number | `15` | Timeout for each matrix job. |
 
 ### `wp-release.yml` - WordPress plugin release
 
@@ -409,14 +493,17 @@ Outputs:
 | `version` | Version extracted from the plugin header. |
 | `released` | `'true'` when a GitHub release was created, `'false'` when skipped. |
 
-**Fixed shape (no inputs):**
+**Fixed release behavior:**
 
 - Version regex: `^[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+)?$`. Pre-release versions (`X.Y.Z-beta.N`, etc.) are auto-marked `prerelease` on the GitHub release.
-- Production build: PHP 8.3 + `composer install --no-dev --optimize-autoloader`.
+- Production build: PHP 8.3 + a non-interactive optimized Composer install.
 - Translations: `msgfmt` runs over `languages/*.po` when any exist. `vendor/` and the compiled `.mo` files are bundled into the zip.
 - rsync exclude list (kept identical across consumers): `release/`, `.git/`, `.github/`, `.claude/`, `node_modules/`, `composer.json`, `composer.lock`, `package.json`, `package-lock.json`, `biome.json`, `phpcs.xml`, `phpcs.xml.dist`, `phpstan.neon`, `phpstan-bootstrap.php`, `phpstan-bootstrap.stub`, `*.log`, `.gitignore`, `CLAUDE.md`, `AGENTS.md`, `.DS_Store`. `vendor/` and `README.md` are kept in the zip.
 
-The release job tags the current commit, builds `<slug>-<version>.zip`, and creates a GitHub release with `--generate-notes`. If the latest tag already matches the header version and `force` is `false`, the workflow exits with a notice and the `released` output is `'false'`.
+The release job tags the current commit, builds `<slug>-<version>.zip`, creates
+a SHA-256 checksum, and publishes both files with generated release notes. If
+the latest tag already matches the header version and `force` is `false`, the
+workflow exits with a notice and the `released` output is `'false'`.
 
 The `plugin-slug` input exists for plugins where the slug currently differs from the repo name (`zw-cacheman` -> `zuidwest-cache-manager`, `zw-liveblog` -> `zuidwest-liveblog`, `zw-gr26-wp` -> `zw-gr26`). Those plugins have open rename issues; once landed, they can drop the override.
 

--- a/workflow-templates/workflow-quality.yml
+++ b/workflow-templates/workflow-quality.yml
@@ -1,0 +1,40 @@
+---
+name: Workflow syntax
+
+"on":
+  push:
+    branches: [main]
+    paths:
+      - '.github/actions/**'
+      - '.github/workflows/**'
+  pull_request:
+    paths:
+      - '.github/actions/**'
+      - '.github/workflows/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  actionlint:
+    name: actionlint
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: '1.26.x'
+          cache: false
+
+      - name: Install actionlint
+        run: go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
+
+      - name: Validate workflows
+        run: actionlint -color

--- a/workflow-templates/wp-js-lint.yml
+++ b/workflow-templates/wp-js-lint.yml
@@ -5,6 +5,7 @@ name: JS Lint
   push:
     branches: [main]
     paths:
+      - '.github/workflows/wp-js-lint.yml'
       - '**/*.js'
       - '**/*.ts'
       - '**/*.css'
@@ -13,6 +14,7 @@ name: JS Lint
       - 'biome.json'
   pull_request:
     paths:
+      - '.github/workflows/wp-js-lint.yml'
       - '**/*.js'
       - '**/*.ts'
       - '**/*.css'
@@ -24,6 +26,12 @@ name: JS Lint
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     uses: oszuidwest/.github-templates/.github/workflows/wp-js-ci.yml@v2
+    with:
+      npm-audit: true

--- a/workflow-templates/wp-lint.yml
+++ b/workflow-templates/wp-lint.yml
@@ -6,6 +6,7 @@ name: Lint
     branches: [main]
     paths:
       - '**/*.php'
+      - '.github/workflows/wp-lint.yml'
       - 'composer.json'
       - 'composer.lock'
       - 'phpcs.xml'
@@ -16,6 +17,7 @@ name: Lint
   pull_request:
     paths:
       - '**/*.php'
+      - '.github/workflows/wp-lint.yml'
       - 'composer.json'
       - 'composer.lock'
       - 'phpcs.xml'
@@ -28,6 +30,14 @@ name: Lint
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     uses: oszuidwest/.github-templates/.github/workflows/wp-ci.yml@v2
+    with:
+      composer-audit: true
+      exact-pot-validation: true
+      strict-composer-validation: true

--- a/workflow-templates/wp-release.yml
+++ b/workflow-templates/wp-release.yml
@@ -12,6 +12,10 @@ name: Release
 permissions:
   contents: read
 
+concurrency:
+  group: release
+  cancel-in-progress: false
+
 jobs:
   release:
     uses: oszuidwest/.github-templates/.github/workflows/wp-release.yml@v2

--- a/workflow-templates/wp-tests.yml
+++ b/workflow-templates/wp-tests.yml
@@ -1,0 +1,43 @@
+---
+name: Tests
+
+"on":
+  push:
+    branches: [main]
+    paths:
+      - '**/*.php'
+      - '.github/workflows/wp-tests.yml'
+      - 'composer.json'
+      - 'composer.lock'
+      - 'patchwork.json'
+      - 'phpunit.xml'
+      - 'phpunit.xml.dist'
+      - 'scripts/check-coverage.php'
+      - 'tests/**'
+  pull_request:
+    paths:
+      - '**/*.php'
+      - '.github/workflows/wp-tests.yml'
+      - 'composer.json'
+      - 'composer.lock'
+      - 'patchwork.json'
+      - 'phpunit.xml'
+      - 'phpunit.xml.dist'
+      - 'scripts/check-coverage.php'
+      - 'tests/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  phpunit:
+    uses: oszuidwest/.github-templates/.github/workflows/wp-tests.yml@v2
+    # Enable when composer.json defines a coverage script that writes
+    # coverage.xml. The threshold remains consumer-owned.
+    # with:
+    #   coverage-php: '8.4'


### PR DESCRIPTION
## Summary

- add Actionlint validation for reusable and copy-paste workflows using the official tagged `rhysd/actionlint` module
- add backward-compatible WP CI inputs for strict Composer validation, dependency audits, exact POT validation, and Plugin Check scoping
- add configurable Node version, npm audit, commands, and timeouts to WP JS CI
- add a reusable PHPUnit matrix with optional coverage artifact upload
- improve WordPress release version selection, non-interactive installs, checksums, and GitHub release publication through `softprops/action-gh-release`
- add caller templates with visible concurrency and opt-in strict quality settings
- preserve the existing Node 24 compatibility setting in WP CI

## Compatibility

Existing `@v2` callers retain their current audit and strict-validation defaults. New inputs and workflows are additive. The copy-paste templates opt into the stronger checks for new consumers. Breaking release ordering and packaging changes are intentionally deferred to v3.

## Verification

- `git diff --check`
- `yamllint .github/workflows workflow-templates config-templates`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -color .github/workflows/*.yml workflow-templates/*.yml`