### PR TITLE
build(deps): bump Go to 1.26.6

### DIFF
--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module local/templates-tools
 
-go 1.26.5
+go 1.26.6
 
 tool (
 	golang.org/x/tools/cmd/deadcode


### PR DESCRIPTION
## Summary

- bump the centrally managed Go analysis-tool module from Go 1.26.5 to 1.26.6
- keep the shared CI tool pins on the patched Go toolchain

## Validation

- cd tools && go mod tidy -diff
- cd tools && go mod verify
- git diff --check
- yamllint .github/workflows workflow-templates config-templates
- actionlint .github/workflows/*.yml workflow-templates/*.yml
- no stale Go 1.26.0-1.26.5 pins remain