### PR TITLE
chore(go): support Go 1.27 tooling

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -7,7 +7,7 @@ name: Go CI
       golangci-lint-version:
         description: 'golangci-lint version (pinned, no v-prefix stripping)'
         type: string
-        default: 'v2.12.1'
+        default: 'v2.13.0'
       go-version-file:
         description: 'Path to file used by setup-go to derive Go version'
         type: string

--- a/README.md
+++ b/README.md
@@ -197,19 +197,22 @@ jobs:
   ci:
     uses: oszuidwest/.github-templates/.github/workflows/go-ci.yml@v2
     with:
-      golangci-lint-version: v2.12.1
+      golangci-lint-version: v2.13.0
 ```
 
 Inputs:
 
 | Input | Type | Required | Default | Notes |
 |-------|------|----------|---------|-------|
-| `golangci-lint-version` | string | no | `v2.12.1` | Passed to `golangci/golangci-lint-action`. |
+| `golangci-lint-version` | string | no | `v2.13.0` | Passed to `golangci/golangci-lint-action`. |
 | `go-version-file` | string | no | `go.mod` | Passed to `actions/setup-go`. |
 | `enable-frontend` | boolean | no | `false` | Adds the frontend lint job. |
 | `frontend-tool` | string | no | `bun` | Only `bun` is supported. |
+| `deadcode-version` | string | no | `''` | Empty uses the `golang.org/x/tools` version in `tools/go.mod`. |
+| `govulncheck-version` | string | no | `''` | Empty uses the `golang.org/x/vuln` version in `tools/go.mod`. |
+| `staticcheck-version` | string | no | `''` | Empty uses the `honnef.co/go/tools` version in `tools/go.mod`. |
 
-The Go job runs `go test -race -shuffle=on -v ./...`, `go vet`, `go fmt` with diff check, golangci-lint, `deadcode`, `govulncheck`, and `staticcheck`. Consumers must keep `deadcode`, `govulncheck`, and `staticcheck` available through Go tool directives in `go.mod`.
+The Go job runs `go test -race -shuffle=on -v ./...`, `go vet`, `go fmt` with diff check, golangci-lint, `deadcode`, `govulncheck`, and `staticcheck`. By default, the reusable workflow resolves and installs `deadcode`, `govulncheck`, and `staticcheck` from this repository's `tools/go.mod`; consumers can override those versions through the corresponding inputs without adding tool directives to their own module.
 
 ### `go-release.yml` - Go release
 

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module local/templates-tools
 
-go 1.26.6
+go 1.27.0
 
 tool (
 	golang.org/x/tools/cmd/deadcode
@@ -17,5 +17,5 @@ require (
 	golang.org/x/telemetry v0.0.0-20260508192327-42602be52be6 // indirect
 	golang.org/x/tools v0.45.0 // indirect
 	golang.org/x/vuln v1.3.0 // indirect
-	honnef.co/go/tools v0.7.0 // indirect
+	honnef.co/go/tools v0.8.0-rc.1 // indirect
 )

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -2,8 +2,8 @@ github.com/BurntSushi/toml v1.4.1-0.20240526193622-a339e1f7089c h1:pxW6RcqyfI9/k
 github.com/BurntSushi/toml v1.4.1-0.20240526193622-a339e1f7089c/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/google/go-cmdtest v0.4.1-0.20220921163831-55ab3332a786 h1:rcv+Ippz6RAtvaGgKxc+8FQIpxHgsF+HBzPyYL2cyVU=
 github.com/google/go-cmdtest v0.4.1-0.20220921163831-55ab3332a786/go.mod h1:apVn/GCasLZUVpAJ6oWAuyP7Ne7CEsQbTnc0plM3m+o=
-github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
-github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/renameio v0.1.0 h1:GOZbcHa3HfsPKPlmyPyN2KEohoMXOhdMbHrvbpl2QaA=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 golang.org/x/exp/typeparams v0.0.0-20260709172345-9ea1abe57597 h1:cn20scKrWugMTULngNFbVZMhpGSg0KAV5AVswG8SCI8=
@@ -24,5 +24,5 @@ golang.org/x/tools/go/packages/packagestest v0.1.1-deprecated h1:1h2MnaIAIXISqTF
 golang.org/x/tools/go/packages/packagestest v0.1.1-deprecated/go.mod h1:RVAQXBGNv1ib0J382/DPCRS/BPnsGebyM1Gj5VSDpG8=
 golang.org/x/vuln v1.3.0 h1:hZYzR8uRhYhDSX88d+40TWbKAVw7BIvRWm26rtEn8jw=
 golang.org/x/vuln v1.3.0/go.mod h1:MIY2PaR1y52stzZM3uHBboUAdVJvSVMl5nP3OQrwQaE=
-honnef.co/go/tools v0.7.0 h1:w6WUp1VbkqPEgLz4rkBzH/CSU6HkoqNLp6GstyTx3lU=
-honnef.co/go/tools v0.7.0/go.mod h1:pm29oPxeP3P82ISxZDgIYeOaf9ta6Pi0EWvCFoLG2vc=
+honnef.co/go/tools v0.8.0-rc.1 h1:wqMm2kjcEXMOr+6yau+pdKqJKe6l2N1aKPkpini+Kzk=
+honnef.co/go/tools v0.8.0-rc.1/go.mod h1:XA+OnlRA9EDh/ukGvXMNSZNKGwFQJ+5dER0ioUkOxks=


### PR DESCRIPTION
## Summary

- update the reusable Go CI default from golangci-lint v2.12.1 to v2.13.0 for Go 1.27 compatibility
- upgrade the central tools module to Go 1.27.0
- pin Staticcheck to official 2026.2rc1 (`honnef.co/go/tools v0.8.0-rc.1`); stable v0.7.0 cannot decode Go 1.27 export data
- refresh only dependency checksums required by Go 1.27 `go mod tidy` and the Staticcheck pin
- document all `go-ci.yml` input defaults and clarify central analysis-tool resolution

## Validation

- `git diff --check`
- `yamllint .github/workflows workflow-templates config-templates`
- `GOTOOLCHAIN=go1.27.0 go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/*.yml workflow-templates/*.yml` (actionlint v1.7.12, built with Go 1.27.0)
- `GOTOOLCHAIN=go1.27.0 go mod verify` in `tools/`
- `GOTOOLCHAIN=go1.27.0 go mod tidy` in `tools/` (fixed point)
- `GOTOOLCHAIN=go1.27.0 go tool staticcheck -version` (`staticcheck 2026.2rc1`)
- `GOTOOLCHAIN=go1.27.0 go tool govulncheck -version` (`govulncheck v1.3.0`)
- Go 1.27 `go fix ./...` and standalone `modernize -fix ./...` were checked in `tools/`; both correctly report no packages because the module contains tool directives and no Go source
- representative consumer smoke: [zwfm-audiologger CI](https://github.com/oszuidwest/zwfm-audiologger/actions/runs/32341405553/job/96341097103) passed with Go 1.27.0, golangci-lint v2.13.0, and Staticcheck v0.8.0-rc.1 using this reusable workflow shape

## Required manual release after merge

Do not tag the PR head. After this PR is merged, create patch tag `v2.7.4` on the exact merge commit and move `v2` to that immutable tag, following the README maintenance contract:

```bash
git fetch origin main --tags
git switch main
git pull --ff-only
MERGE_SHA="$(gh pr view https://github.com/oszuidwest/.github-templates/pull/52 --json mergeCommit --jq .mergeCommit.oid)"
git merge-base --is-ancestor "$MERGE_SHA" origin/main
VERSION=v2.7.4
MAJOR=v2
git tag "$VERSION" "$MERGE_SHA"
git tag -f "$MAJOR" "$VERSION"
git push origin "$VERSION"
git push --force origin "refs/tags/$MAJOR"
```

The `git merge-base` check must succeed before tagging. No merge or tag is performed by this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the default linting tool version to 2.13.0.
  * Added configurable versions for deadcode, govulncheck, and staticcheck.
  * The CI workflow now installs these tools by default from the repository’s tool configuration.
  * Updated the Go toolchain requirement and upgraded static analysis tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->