### PR TITLE
fix(go): allow disabling deadcode analysis

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -22,6 +22,10 @@ name: Go CI
           Only "bun" is supported in v1.
         type: string
         default: 'bun'
+      enable-deadcode:
+        description: 'Run deadcode analysis'
+        type: boolean
+        default: true
       deadcode-version:
         description: >-
           Override deadcode version. Empty = use version pinned in
@@ -113,13 +117,17 @@ jobs:
           echo "  govulncheck=$govulncheck_v"
           echo "  staticcheck=$staticcheck_v"
 
-      - name: Install Go analysis tools
+      - name: Install deadcode
+        if: inputs.enable-deadcode
         env:
           DEADCODE_VERSION: ${{ steps.tool_versions.outputs.deadcode }}
+        run: go install "golang.org/x/tools/cmd/deadcode@${DEADCODE_VERSION}"
+
+      - name: Install Go analysis tools
+        env:
           GOVULNCHECK_VERSION: ${{ steps.tool_versions.outputs.govulncheck }}
           STATICCHECK_VERSION: ${{ steps.tool_versions.outputs.staticcheck }}
         run: |
-          go install "golang.org/x/tools/cmd/deadcode@${DEADCODE_VERSION}"
           go install "golang.org/x/vuln/cmd/govulncheck@${GOVULNCHECK_VERSION}"
           go install "honnef.co/go/tools/cmd/staticcheck@${STATICCHECK_VERSION}"
 
@@ -128,6 +136,7 @@ jobs:
       # platform is not a false positive. Trade-off: dead production code
       # that still has tests is not reported.
       - name: Check for dead code
+        if: inputs.enable-deadcode
         run: |
           deadcode_output=$(deadcode -test ./...)
           if [ -n "$deadcode_output" ]; then

--- a/README.md
+++ b/README.md
@@ -208,11 +208,14 @@ Inputs:
 | `go-version-file` | string | no | `go.mod` | Passed to `actions/setup-go`. |
 | `enable-frontend` | boolean | no | `false` | Adds the frontend lint job. |
 | `frontend-tool` | string | no | `bun` | Only `bun` is supported. |
+| `enable-deadcode` | boolean | no | `true` | Installs and runs deadcode analysis. |
 | `deadcode-version` | string | no | `''` | Empty uses the `golang.org/x/tools` version in `tools/go.mod`. |
 | `govulncheck-version` | string | no | `''` | Empty uses the `golang.org/x/vuln` version in `tools/go.mod`. |
 | `staticcheck-version` | string | no | `''` | Empty uses the `honnef.co/go/tools` version in `tools/go.mod`. |
 
 The Go job runs `go test -race -shuffle=on -v ./...`, `go vet`, `go fmt` with diff check, golangci-lint, `deadcode`, `govulncheck`, and `staticcheck`. By default, the reusable workflow resolves and installs `deadcode`, `govulncheck`, and `staticcheck` from this repository's `tools/go.mod`; consumers can override those versions through the corresponding inputs without adding tool directives to their own module.
+
+Some Go 1.27 consumer dependency and type graphs can currently trigger an upstream `x/tools` RTA panic when deadcode analyzes generic methods. This is not a general Go 1.27 failure: minimal generic-method programs continue to pass. Affected consumers can temporarily set `enable-deadcode: false`; this skips only deadcode installation and execution, while `govulncheck` and `staticcheck` remain enabled. The broader Go 1.27 tools compatibility work is tracked in [golang/go#77549](https://github.com/golang/go/issues/77549). Remove the override or set it back to `true` as soon as the affected `x/tools` analysis is fixed.
 
 ### `go-release.yml` - Go release
 


### PR DESCRIPTION
## Summary

- add backward-compatible `enable-deadcode` input to `go-ci.yml`, defaulting to `true`
- skip both deadcode installation and execution when disabled
- keep govulncheck and staticcheck installation/execution unconditional
- document the temporary Go 1.27 consumer-graph escape hatch and require consumers to re-enable it after the upstream analysis is fixed

## Reproduction

`zwfm-babbel` exposes a graph-specific upstream `x/tools` RTA failure under Go 1.27:

```bash
GOTOOLCHAIN=go1.27.0 \
  go run golang.org/x/tools/cmd/deadcode@master ./cmd/babbel
```

`@master` resolves to `v0.49.1-0.20260819203639-c62e53519fb7` and exits 1 with a nil dereference in `golang.org/x/tools/go/callgraph/rta.(*rta).visitFunc(..., 0x0)` at `rta.go:262`, reached through `rta.Analyze` and `deadcode.go:211`. x/tools v0.45 and v0.48 instead fail with `panic: Int` in `rta.(*rta).addRuntimeType`.

The failure is not universal: deadcode succeeds for the repository's `./tools` graph and for minimal empty-main and explicit `math/rand/v2.Rand.N` generic-method reproductions. This opt-out is therefore narrowly scoped to affected consumer dependency/type graphs. [golang/go#77549](https://github.com/golang/go/issues/77549) provides the broader Go 1.27 tools-compatibility context.

## Tests

- `yamllint .github/workflows workflow-templates config-templates`
- `actionlint .github/workflows/*.yml workflow-templates/*.yml`
- ShellCheck validation of the analysis-version resolver
- `git diff --check`
- manual workflow review confirms `enable-deadcode: false` guards only `Install deadcode` and `Check for dead code`; govulncheck/staticcheck remain unconditional

## Release

`v2.7.4` does not exist yet. After this PR is merged, create one `v2.7.4` tag on this PR's merge commit and move the `v2` tag directly to that same commit. That single release will include both #52 (Go 1.27 tooling) and this deadcode escape hatch. Do not tag the intermediate #52 merge commit separately.
